### PR TITLE
Fix/session boot id cross run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+.env
+*.db
+*.db-shm
+*.db-wal
+scan-results/
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.pytest_cache/
+.ruff_cache/
+dist/
+*.egg-info/
+.uv/
+.claude/
+
+# Electron desktop launcher
+desktop/node_modules/
+desktop/dist/
+desktop/build/icon-source.png
+
+# Per-organization scope presets — each org's own targets, not shared
+dast/scope_presets/*.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -576,5 +576,5 @@ Set `AWS_PROFILE` — credentials auto-refresh on `ExpiredTokenException`.
 
 ---
 
-**Last Updated:** 2026-07-15
-**Version:** 0.8.0
+**Last Updated:** 2026-08-04
+**Version:** 0.8.1

--- a/dast/proxy/api/status_routes.py
+++ b/dast/proxy/api/status_routes.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from fastapi.responses import JSONResponse
@@ -15,9 +16,23 @@ from dast.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Unique identity of THIS proxy process, regenerated on every startup. The
+# dashboard stamps every persisted session id with the boot id of the process
+# that owned it, then only resumes auto-saving into that session when the boot
+# id still matches. Two projects (or a restart) sharing the same
+# 127.0.0.1:<port> origin also share that origin's localStorage; without this
+# stamp the dashboard would silently resume a stale session left by a previous
+# run and overwrite its file with the new run's traffic.
+_BOOT_ID = uuid.uuid4().hex
+
 
 def make_router(ctx: DashboardContext) -> APIRouter:
     router = APIRouter()
+
+    @router.get("/api/boot-id")
+    async def get_boot_id():
+        """Identity of the running proxy process (see _BOOT_ID)."""
+        return {"boot_id": _BOOT_ID}
 
     @router.get("/api/status")
     async def get_status():

--- a/dast/proxy/ui/index.html
+++ b/dast/proxy/ui/index.html
@@ -1928,6 +1928,9 @@ Port: 8080</div>
   <div class="ctx-item" onclick="_ctxSendIntruder()">
     <span class="ctx-icon">⚡</span> Send to Intruder
   </div>
+  <div class="ctx-item" onclick="_ctxSendDecoder()" title="Send the selected text to the Decoder (Extras tab)">
+    <span class="ctx-icon">⇄</span> Send to Decoder
+  </div>
   <div class="ctx-item ctx-sep" onclick="_ctxSendAI()">
     <span class="ctx-icon">▶</span> Scan with AI
   </div>

--- a/dast/proxy/ui/js/10-state-core.js
+++ b/dast/proxy/ui/js/10-state-core.js
@@ -249,6 +249,32 @@ let _lastKnownEntryCount = 0;
 let _wsHeartbeatTimer = null;
 let _wsReconnectDelay = 2000;
 
+// Identity of the proxy process we are talking to. A persisted session id is
+// only resumed when it was stamped with this same boot id (see
+// reconcileSessionBoot). Shared across the concatenated UI scripts.
+let _bootId = null;
+let _bootReconcilePromise = null;
+
+// Drop any persisted session id that does NOT belong to the running proxy
+// process. localStorage is keyed by origin (127.0.0.1:<port>), so a restart or
+// a second project on the same port would otherwise silently resume a stale
+// session and overwrite its file with the new run's traffic. A session id is
+// only ever stamped with a boot id after an explicit save or load, so a fresh
+// launch always starts on a clean untitled session.
+async function reconcileSessionBoot() {
+  try {
+    const r = await fetch('/api/boot-id');
+    if (!r.ok) return;
+    const d = await r.json();
+    _bootId = d.boot_id || null;
+    if (_bootId && localStorage.getItem('dast-session-boot') !== _bootId) {
+      localStorage.removeItem('dast-session-id');
+      localStorage.removeItem('dast-session-name');
+      localStorage.removeItem('dast-session-boot');
+    }
+  } catch (_) {}
+}
+
 async function loadAllEntries() {
   try {
     const r = await fetch('/api/entries');
@@ -277,6 +303,8 @@ async function loadAllEntries() {
       updateStats();
     }
 
+    // Only restore a session that belongs to the running proxy process.
+    try { await (_bootReconcilePromise || Promise.resolve()); } catch (_) {}
     const savedId   = localStorage.getItem('dast-session-id');
     const savedName = localStorage.getItem('dast-session-name');
     if (savedId && !_currentSessionId) {
@@ -319,6 +347,9 @@ function connect() {
     // Eager plugin fetch so plugin-gated tabs (e.g. GraphQL) hide/show
     // correctly even before the user ever opens the Plugins tab.
     loadPlugins();
+    // Resolve the proxy's boot id before restoring any persisted session, so a
+    // stale session from another run/project is never silently resumed.
+    _bootReconcilePromise = reconcileSessionBoot();
     // Always reload entries on reconnect — we may have missed updates while disconnected
     loadAllEntries();
   };

--- a/dast/proxy/ui/js/80-setup-status-sessions.js
+++ b/dast/proxy/ui/js/80-setup-status-sessions.js
@@ -285,11 +285,15 @@ function _setCurrentSession(id, name) {
   if (id) {
     localStorage.setItem('dast-session-id', id);
     if (name) localStorage.setItem('dast-session-name', name);
+    // Stamp the owning proxy process so this session is only resumed by the
+    // same run (see reconcileSessionBoot). Set only on an explicit save/load.
+    if (_bootId) localStorage.setItem('dast-session-boot', _bootId);
     _showAutoSaveLabel(true);
     _maybeStartAutoSave();
   } else {
     localStorage.removeItem('dast-session-id');
     localStorage.removeItem('dast-session-name');
+    localStorage.removeItem('dast-session-boot');
   }
 }
 

--- a/dast/proxy/ui/js/99-bootstrap-ctxmenu.js
+++ b/dast/proxy/ui/js/99-bootstrap-ctxmenu.js
@@ -2,6 +2,9 @@
 
 (function() {
   let _ctxId = null;
+  // Text selected when the menu opened. Captured here because clicking a menu
+  // item collapses the selection, so "Send to Decoder" could not read it later.
+  let _ctxSelText = '';
 
   function getMenu() { return document.getElementById('ctx-menu'); }
 
@@ -13,6 +16,8 @@
 
   function showMenu(x, y, entryId) {
     _ctxId = entryId;
+    try { _ctxSelText = (window.getSelection && window.getSelection().toString()) || ''; }
+    catch (_) { _ctxSelText = ''; }
     const m = getMenu();
     if (!m) return;
     m.classList.add('visible');
@@ -72,6 +77,24 @@
   };
   window._ctxSendIntruder = function() {
     if (_ctxId) { itrLoadEntry(_ctxId); hideMenu(); switchMain('intruder'); }
+  };
+  // Send the selected text (not the whole entry) to the Extras > Decoder tab.
+  // switchExtrasSub('decoder') runs decoderInit() against an empty input, so we
+  // set the value and re-run the transform afterwards.
+  window._ctxSendDecoder = function() {
+    const text = (_ctxSelText || '').trim();
+    hideMenu();
+    if (!text) {
+      if (window.showToast) showToast('Select some text first', true);
+      return;
+    }
+    switchMain('extras');
+    switchExtrasSub('decoder');
+    const input = document.getElementById('dec-input');
+    if (input) {
+      input.value = text;
+      if (typeof decoderRun === 'function') decoderRun();
+    }
   };
   window._ctxSendAI = function() {
     if (_ctxId) {

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -27,9 +27,14 @@ const appIcon = nativeImage.createFromPath(ICON_PATH);
 // ---------------------------------------------------------------------------
 // Config — overridable via environment
 // ---------------------------------------------------------------------------
-const DASHBOARD_PORT = parseInt(process.env.DASHBOARD_PORT || "8088", 10);
-const PROXY_PORT = parseInt(process.env.PROXY_PORT || "8080", 10);
-const DASHBOARD_URL = `http://127.0.0.1:${DASHBOARD_PORT}`;
+// Preferred ports (env override or defaults). These are only a starting point:
+// resolvePorts() picks a free port if the preferred one is already taken, so a
+// stale backend left over from a previous run (or a second project on the same
+// machine) can never make us bind — or worse, silently attach to — a port we
+// don't own. Mutable because the resolved values may differ from the preferred.
+let DASHBOARD_PORT = parseInt(process.env.DASHBOARD_PORT || "8088", 10);
+let PROXY_PORT = parseInt(process.env.PROXY_PORT || "8080", 10);
+let DASHBOARD_URL = `http://127.0.0.1:${DASHBOARD_PORT}`;
 // The backend lives one level up from desktop/. Run it via uv so the launcher
 // needs no bundled Python (Phase 1 assumes uv is installed on the machine).
 const REPO_ROOT = path.resolve(__dirname, "..");
@@ -39,6 +44,53 @@ let mainWindow = null;
 let tray = null;
 let backendReady = false;
 let isQuitting = false;
+
+// ---------------------------------------------------------------------------
+// Port resolution — never bind (or attach to) a port we don't own
+// ---------------------------------------------------------------------------
+// True only if we can bind the port ourselves right now. A port held by a
+// stale backend answers connections, so a plain "can I connect?" probe would
+// wrongly report it usable and we'd attach to that old process — exactly the
+// bug where the desktop showed a previous run's session.
+function isPortFree(port) {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => server.close(() => resolve(true)));
+    server.listen(port, "127.0.0.1");
+  });
+}
+
+// Ask the OS for a free ephemeral port (bind to 0, read the assigned port).
+function getEphemeralPort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+// Return the preferred port if free, otherwise a free ephemeral one. `exclude`
+// guards against handing out the same port twice when both fall back.
+async function resolvePort(preferred, label, exclude = null) {
+  if (preferred !== exclude && (await isPortFree(preferred))) return preferred;
+  let port = await getEphemeralPort();
+  while (port === exclude) port = await getEphemeralPort();
+  console.log(
+    `[frieren-desktop] ${label} port ${preferred} is busy — using free port ${port} instead.`
+  );
+  return port;
+}
+
+// Resolve both ports before anything reads them, and rebuild DASHBOARD_URL.
+async function resolvePorts() {
+  PROXY_PORT = await resolvePort(PROXY_PORT, "proxy");
+  DASHBOARD_PORT = await resolvePort(DASHBOARD_PORT, "dashboard", PROXY_PORT);
+  DASHBOARD_URL = `http://127.0.0.1:${DASHBOARD_PORT}`;
+}
 
 // ---------------------------------------------------------------------------
 // Backend lifecycle
@@ -279,6 +331,10 @@ app.whenReady().then(async () => {
   if (process.platform === "darwin" && app.dock && !appIcon.isEmpty()) {
     app.dock.setIcon(appIcon);
   }
+
+  // Resolve free ports BEFORE createTray/createWindow/startBackend, all of
+  // which read PROXY_PORT/DASHBOARD_PORT/DASHBOARD_URL.
+  await resolvePorts();
 
   createTray();
   createWindow();

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dast-ai-desktop",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Frieren DAST-AI desktop launcher — native window for the proxy + dashboard",
   "main": "main.js",
   "author": "Frieren DAST-AI contributors",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,8 +2,8 @@
 
 > For Claude Code conventions, commands, and key files see [CLAUDE.md](../CLAUDE.md).
 
-**Version:** 0.8.0
-**Last Updated:** 2026-06-09
+**Version:** 0.8.1
+**Last Updated:** 2026-08-04
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dast-ai"
-version = "0.8.0"
+version = "0.8.1"
 description = "AI-driven DAST: browser-based security testing with LLM feedback loops"
 requires-python = ">=3.12"
 dependencies = [

--- a/tests/unit/test_status_routes.py
+++ b/tests/unit/test_status_routes.py
@@ -71,3 +71,15 @@ def test_sticky_unavailable_flag_forces_offline_even_with_key(monkeypatch):
         assert body["ai_enabled"] is False
     finally:
         _reset_provider()
+
+
+def test_boot_id_is_returned_and_stable_within_process():
+    # The dashboard stamps every persisted session id with this value so a stale
+    # session from another run/project is never silently resumed. It must be a
+    # non-empty string and identical on every call within the same process.
+    client = _client()
+    first = client.get("/api/boot-id").json()
+    assert isinstance(first.get("boot_id"), str)
+    assert first["boot_id"]
+    second = client.get("/api/boot-id").json()
+    assert second["boot_id"] == first["boot_id"]


### PR DESCRIPTION
  Fixes the bug where the desktop app resumed an old session from another run or project,
  adds "Send to Decoder" to the context menu, makes the launcher pick a free port, and
  restores the missing .gitignore. Version bumped to 0.8.1.
