### PR TITLE
refactor(dedup): consolidate JWT, SignalR, and raw-HTTP helpers (Phase 2)

### DIFF
--- a/dast/agents/blazor_agent.py
+++ b/dast/agents/blazor_agent.py
@@ -34,6 +34,7 @@ from urllib.parse import urlparse, urlunparse
 from dast.ai.agent_base import AgentFinding, VulnAgent
 from dast.payloads.loader import get_payloads
 from dast.proxy.plugin_manager import log_event
+from dast.proxy.signalr import MZ_HEADER, SIGNALR_SEPARATOR, encode_varint
 from dast.scanners.active_checks import _fmt_http_pair, _send
 from dast.utils.logger import get_logger
 
@@ -45,10 +46,10 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 # SignalR text-protocol record separator
-_SIGNALR_SEP = "\x1e"
+_SIGNALR_SEP = SIGNALR_SEPARATOR
 
 # MZ header — confirms a .NET PE assembly
-_MZ_HEADER = b"\x4d\x5a"
+_MZ_HEADER = MZ_HEADER
 
 # Patterns that confirm a Blazor application
 _BLAZOR_WASM_RE = re.compile(
@@ -1109,13 +1110,7 @@ class BlazorAgent(VulnAgent):
 
         def _mp_frame(obj) -> bytes:
             payload = msgpack.packb(obj, use_bin_type=True)
-            n, varint = len(payload), b""
-            while True:
-                b = n & 0x7f; n >>= 7
-                varint += bytes([b | (0x80 if n else 0)])
-                if not n:
-                    break
-            return varint + payload
+            return encode_varint(len(payload)) + payload
 
         # ── 2. Handshake (blazorpack) ─────────────────────────────────────
         handshake = json.dumps({"protocol": "blazorpack", "version": 1}) + _SIGNALR_SEP

--- a/dast/agents/business_logic_agent.py
+++ b/dast/agents/business_logic_agent.py
@@ -28,6 +28,7 @@ from dast.ai import bedrock_client
 from dast.ai.agent_base import AgentFinding, VulnAgent
 from dast.ai.payload_generator import _sanitize_for_prompt
 from dast.scanners.active_checks import _fmt_http_pair, _inject_query, _send
+from dast.utils.jwt import b64url_encode_json, decode_jwt_claims, decode_jwt_header
 from dast.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -162,35 +163,9 @@ _JWT_RE = re.compile(
 def _is_jwt(value: str) -> bool:
     return bool(_JWT_RE.match(str(value).strip()))
 
-def _decode_jwt_claims(token: str) -> Optional[dict]:
-    """
-    Decode JWT claims payload without verifying signature.
-    Returns dict of claims or None on failure.
-    """
-    import base64
-    try:
-        parts = token.split(".")
-        if len(parts) < 2:
-            return None
-        # Add padding
-        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
-        payload_bytes = base64.urlsafe_b64decode(payload_b64)
-        return _json.loads(payload_bytes)
-    except Exception:
-        return None
-
-
-def _decode_jwt_header(token: str) -> Optional[dict]:
-    """Decode JWT header without verifying signature."""
-    import base64
-    try:
-        parts = token.split(".")
-        if not parts:
-            return None
-        hdr_b64 = parts[0] + "=" * (-len(parts[0]) % 4)
-        return _json.loads(base64.urlsafe_b64decode(hdr_b64))
-    except Exception:
-        return None
+# JWT decode helpers now live in dast.utils.jwt; aliased for in-module callers.
+_decode_jwt_claims = decode_jwt_claims
+_decode_jwt_header = decode_jwt_header
 
 
 def _build_jwt_alg_none(original_token: str, extra_claims: Optional[dict] = None) -> str:
@@ -198,20 +173,13 @@ def _build_jwt_alg_none(original_token: str, extra_claims: Optional[dict] = None
     Build an alg:none JWT preserving the original claims payload,
     optionally injecting extra claims (e.g. role: admin).
     """
-    import base64
-
-    def _b64(data: dict) -> str:
-        return base64.urlsafe_b64encode(
-            _json.dumps(data, separators=(",", ":")).encode()
-        ).rstrip(b"=").decode()
-
     claims = _decode_jwt_claims(original_token) or {}
     if extra_claims:
         claims.update(extra_claims)
 
     for variant_alg in ("none", "None", "NONE"):
         header = {"alg": variant_alg, "typ": "JWT"}
-        yield f"{_b64(header)}.{_b64(claims)}."
+        yield f"{b64url_encode_json(header)}.{b64url_encode_json(claims)}."
 
 
 def _jwt_probes(key: str, location: str, original_token: str = "") -> List[Dict[str, Any]]:
@@ -266,15 +234,8 @@ def _jwt_probes(key: str, location: str, original_token: str = "") -> List[Dict[
     #   c) For each URL-bearing field: build a token replacing that URL with OOB
     #   d) For header URL fields (jku, x5u): inject into header instead of claims
 
-    import base64
-
     _SSRF_URL = "https://collaborator.dast-ai.internal/jwt-ssrf"
     _URL_RE = re.compile(r'https?://[^\s"\'<>}\]){,]+', re.IGNORECASE)
-
-    def _b64url(d: dict) -> str:
-        return base64.urlsafe_b64encode(
-            _json.dumps(d, separators=(",", ":")).encode()
-        ).rstrip(b"=").decode()
 
     def _find_urls_in_value(val) -> List[str]:
         """Recursively find all http(s) URLs in a value (string, list, dict)."""
@@ -330,7 +291,7 @@ def _jwt_probes(key: str, location: str, original_token: str = "") -> List[Dict[
                 mod_claims.get(claim_key, original_url), original_url, _SSRF_URL
             )
 
-        ssrf_token = f"{_b64url(mod_header)}.{_b64url(mod_claims)}."
+        ssrf_token = f"{b64url_encode_json(mod_header)}.{b64url_encode_json(mod_claims)}."
         probes.append({
             "param_name": key,
             "param_location": location,
@@ -347,16 +308,10 @@ def _jwt_probes(key: str, location: str, original_token: str = "") -> List[Dict[
     # ── 3. kid injection (only if header has kid or alg suggests key lookup) ──
     if (header or {}).get("kid") is not None or alg in ("RS256", "RS384", "RS512", "ES256"):
         kid_payloads = get_payloads("jwt", "kid_injection")
-        import base64
-
-        def _b64url(d: dict) -> str:
-            return base64.urlsafe_b64encode(
-                _json.dumps(d, separators=(",", ":")).encode()
-            ).rstrip(b"=").decode()
 
         for kid_val in kid_payloads[:3]:
             kid_header = {"alg": "none", "typ": "JWT", "kid": kid_val}
-            kid_token = f"{_b64url(kid_header)}.{_b64url(claims or {'sub': 'test'})}."
+            kid_token = f"{b64url_encode_json(kid_header)}.{b64url_encode_json(claims or {'sub': 'test'})}."
             probes.append({
                 "param_name": key,
                 "param_location": location,

--- a/dast/plugins/blazor_detector.py
+++ b/dast/plugins/blazor_detector.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Dict, List, Tuple
 
 from dast.proxy.plugin_base import ProxyPlugin
 from dast.proxy.plugin_manager import log_event
+from dast.proxy.signalr import MZ_HEADER, SIGNALR_SEPARATOR, is_signalr_binary, read_varint
 from dast.utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -31,10 +32,10 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 # SignalR text protocol record separator (0x1e)
-_SIGNALR_SEP = "\x1e"
+_SIGNALR_SEP = SIGNALR_SEPARATOR
 
 # MZ header — marks a Windows PE / .NET assembly
-_MZ_HEADER = b"\x4d\x5a"
+_MZ_HEADER = MZ_HEADER
 
 # Blazor WASM fingerprint patterns (response body)
 _WASM_BODY_RE = re.compile(
@@ -178,86 +179,70 @@ def _parse_blazor_request_body(raw: bytes) -> List[dict]:
     try:
         import msgpack as _mp
 
-        def _read_varint(data: bytes, pos: int):
-            result, shift = 0, 0
-            while pos < len(data):
-                b = data[pos]; pos += 1
-                result |= (b & 0x7f) << shift
-                if not (b & 0x80):
-                    return result, pos
-                shift += 7
-            return result, pos
-
         # Check if this looks like msgpack (varint + fixarray)
-        if len(raw) >= 2:
+        if is_signalr_binary(raw):
+            # Parse all frames
             pos = 0
-            for _ in range(5):
-                if pos >= len(raw): break
-                b = raw[pos]; pos += 1
-                if not (b & 0x80): break
-            if pos < len(raw) and 0x90 <= raw[pos] <= 0x9f:
-                # Parse all frames
-                pos = 0
-                while pos < len(raw):
-                    frame_len, pos = _read_varint(raw, pos)
-                    if frame_len == 0 or pos + frame_len > len(raw):
-                        break
-                    frame = raw[pos:pos+frame_len]; pos += frame_len
+            while pos < len(raw):
+                frame_len, pos = read_varint(raw, pos)
+                if frame_len == 0 or pos + frame_len > len(raw):
+                    break
+                frame = raw[pos:pos+frame_len]; pos += frame_len
+                try:
+                    msg = _mp.unpackb(frame, raw=False, strict_map_key=False)
+                except Exception:
+                    continue
+                if not isinstance(msg, (list, tuple)) or len(msg) < 5:
+                    continue
+                if msg[0] != 1:  # only Invocation type
+                    continue
+                target = msg[3] if len(msg) > 3 else ""
+                args = msg[4] if len(msg) > 4 else None
+
+                if target == "BeginInvokeDotNetFromJS" and isinstance(args, (list, tuple)) and len(args) >= 5:
+                    # args = [callId, assembly, method, dotNetObjectId, argsJson]
+                    args_json_str = args[4]
                     try:
-                        msg = _mp.unpackb(frame, raw=False, strict_map_key=False)
+                        event_args = json.loads(args_json_str) if isinstance(args_json_str, str) else args_json_str
                     except Exception:
                         continue
-                    if not isinstance(msg, (list, tuple)) or len(msg) < 5:
+                    if not isinstance(event_args, (list, tuple)):
                         continue
-                    if msg[0] != 1:  # only Invocation type
+
+                    # First element is the event descriptor
+                    descriptor = event_args[0] if event_args else {}
+                    if not isinstance(descriptor, dict):
                         continue
-                    target = msg[3] if len(msg) > 3 else ""
-                    args = msg[4] if len(msg) > 4 else None
 
-                    if target == "BeginInvokeDotNetFromJS" and isinstance(args, (list, tuple)) and len(args) >= 5:
-                        # args = [callId, assembly, method, dotNetObjectId, argsJson]
-                        args_json_str = args[4]
-                        try:
-                            event_args = json.loads(args_json_str) if isinstance(args_json_str, str) else args_json_str
-                        except Exception:
-                            continue
-                        if not isinstance(event_args, (list, tuple)):
-                            continue
+                    handler_id = descriptor.get("eventHandlerId")
+                    event_name = descriptor.get("eventName", "")
+                    if not isinstance(handler_id, int):
+                        continue
 
-                        # First element is the event descriptor
-                        descriptor = event_args[0] if event_args else {}
-                        if not isinstance(descriptor, dict):
-                            continue
+                    # Second element may contain input field values
+                    input_fields: List[str] = []
+                    if len(event_args) > 1 and isinstance(event_args[1], dict):
+                        event_data = event_args[1]
+                        # For change/input events, "value" is the user-typed content
+                        if "value" in event_data:
+                            input_fields.append("value")
+                        # For custom events, collect all string-valued keys
+                        for k, v in event_data.items():
+                            if isinstance(v, str) and k not in ("type",) and k not in input_fields:
+                                input_fields.append(k)
 
-                        handler_id = descriptor.get("eventHandlerId")
-                        event_name = descriptor.get("eventName", "")
-                        if not isinstance(handler_id, int):
-                            continue
-
-                        # Second element may contain input field values
-                        input_fields: List[str] = []
-                        if len(event_args) > 1 and isinstance(event_args[1], dict):
-                            event_data = event_args[1]
-                            # For change/input events, "value" is the user-typed content
-                            if "value" in event_data:
-                                input_fields.append("value")
-                            # For custom events, collect all string-valued keys
-                            for k, v in event_data.items():
-                                if isinstance(v, str) and k not in ("type",) and k not in input_fields:
-                                    input_fields.append(k)
-
-                        results.append({
-                            "handler_id": handler_id,
-                            "event_name": event_name,
-                            "component": "",
-                            "input_fields": input_fields,
-                        })
-                return results
+                    results.append({
+                        "handler_id": handler_id,
+                        "event_name": event_name,
+                        "component": "",
+                        "input_fields": input_fields,
+                    })
+            return results
     except ImportError:
         pass
 
     # ── text protocol (0x1e-delimited JSON) ──────────────────────────────
-    _SEP = "\x1e"
+    _SEP = SIGNALR_SEPARATOR
     try:
         text = raw.decode("utf-8", errors="replace")
     except Exception:

--- a/dast/plugins/jwt_analyzer.py
+++ b/dast/plugins/jwt_analyzer.py
@@ -11,12 +11,11 @@ Checks:
 
 from __future__ import annotations
 
-import base64
-import json
 import re
 from typing import TYPE_CHECKING, Optional
 
 from dast.proxy.plugin_base import ProxyPlugin
+from dast.utils.jwt import decode_segment
 
 if TYPE_CHECKING:
     from dast.proxy.session_store import ProxyEntry, SessionStore
@@ -29,8 +28,7 @@ _PII_KEYS = {"email", "mail", "phone", "mobile", "ssn", "name", "username", "dob
 
 def _b64_decode(s: str) -> Optional[dict]:
     try:
-        padded = s + "=" * (-len(s) % 4)
-        return json.loads(base64.urlsafe_b64decode(padded))
+        return decode_segment(s)
     except Exception:
         return None
 

--- a/dast/plugins/jwt_tester.py
+++ b/dast/plugins/jwt_tester.py
@@ -15,9 +15,6 @@ Tests performed (payloads from jwt.yaml):
 from __future__ import annotations
 
 import asyncio
-import base64
-import hashlib
-import hmac as _hmac
 import json
 import re
 from typing import TYPE_CHECKING, Optional, Tuple
@@ -27,6 +24,9 @@ import httpx
 from dast.payloads.loader import get_payloads
 from dast.proxy.plugin_base import ProxyPlugin
 from dast.proxy.plugin_manager import log_event
+# JWT/base64url primitives live in dast.utils.jwt. Re-exported under the local
+# underscore names below for backward compatibility (tests import them here).
+from dast.utils.jwt import b64url_decode, b64url_encode, build_token, decode_jwt
 
 if TYPE_CHECKING:
     from dast.proxy.session_store import ProxyEntry, SessionStore
@@ -34,45 +34,12 @@ if TYPE_CHECKING:
 _JWT_RE = re.compile(r"eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.([A-Za-z0-9_-]*)")
 
 
-# ── JWT encoding helpers ───────────────────────────────────────────────────
+# ── JWT encoding helpers (thin aliases over dast.utils.jwt) ─────────────────
 
-def _b64url_decode(s: str) -> bytes:
-    s = s.replace("-", "+").replace("_", "/")
-    padding = 4 - len(s) % 4
-    if padding != 4:
-        s += "=" * padding
-    return base64.b64decode(s)
-
-
-def _b64url_encode(data: bytes) -> str:
-    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
-
-
-def _decode_jwt(token: str) -> Optional[Tuple[dict, dict]]:
-    parts = token.split(".")
-    if len(parts) != 3:
-        return None
-    try:
-        header = json.loads(_b64url_decode(parts[0]))
-        payload = json.loads(_b64url_decode(parts[1]))
-        return header, payload
-    except Exception:
-        return None
-
-
-def _build_token(header: dict, payload: dict, secret: Optional[str] = None) -> str:
-    h = _b64url_encode(json.dumps(header, separators=(",", ":")).encode())
-    p = _b64url_encode(json.dumps(payload, separators=(",", ":")).encode())
-    signing_input = f"{h}.{p}".encode()
-    if secret is None:
-        sig = ""
-    else:
-        alg = header.get("alg", "HS256")
-        hash_fn = {"HS256": hashlib.sha256, "HS384": hashlib.sha384, "HS512": hashlib.sha512}.get(
-            alg, hashlib.sha256
-        )
-        sig = _b64url_encode(_hmac.new(secret.encode(), signing_input, hash_fn).digest())
-    return f"{h}.{p}.{sig}"
+_b64url_decode = b64url_decode
+_b64url_encode = b64url_encode
+_decode_jwt = decode_jwt
+_build_token = build_token
 
 
 def _find_jwt(headers: dict) -> Optional[Tuple[str, str, str]]:

--- a/dast/plugins/passive_scanner.py
+++ b/dast/plugins/passive_scanner.py
@@ -667,13 +667,13 @@ async def _active_cors_probe(entry: "ProxyEntry", rule_id: str) -> Tuple[Optiona
 
 
 def _format_raw_request(entry: "ProxyEntry") -> str:
-    from dast.proxy.session_store import _format_raw_request as _ss_fmt_req
-    return _ss_fmt_req(entry)
+    from dast.proxy.http_format import _format_raw_request as _fmt_req
+    return _fmt_req(entry)
 
 
 def _format_raw_response(entry: "ProxyEntry") -> str:
-    from dast.proxy.session_store import _format_raw_response as _ss_fmt_resp
-    return _ss_fmt_resp(entry)
+    from dast.proxy.http_format import _format_raw_response as _fmt_resp
+    return _fmt_resp(entry)
 
 
 async def _ai_validate_finding(title: str, snippet: str, raw_response_body: str = "") -> Tuple[Optional[bool], str]:

--- a/dast/proxy/http_format.py
+++ b/dast/proxy/http_format.py
@@ -1,0 +1,45 @@
+"""
+Raw HTTP text formatting for evidence.
+
+Single home for turning a `ProxyEntry` into raw HTTP request/response text
+(the format shown as finding evidence). Kept dependency-free so any module can
+import it without risking a circular import with `session_store`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from dast.proxy.session_store import ProxyEntry
+
+
+def _format_raw_request(entry: "ProxyEntry") -> str:
+    """Format a ProxyEntry's request as raw HTTP text (reusable by any caller)."""
+    parsed = urlparse(entry.url)
+    path = (parsed.path or "/") + (f"?{parsed.query}" if parsed.query else "")
+    lines = [f"{entry.method} {path} HTTP/1.1", f"Host: {entry.host}"]
+    for k, v in (entry.request_headers or {}).items():
+        if k.lower() != "host":
+            lines.append(f"{k}: {v}")
+    lines.append("")
+    if entry.request_body:
+        lines.append(entry.request_body.decode("utf-8", errors="replace"))
+    return "\r\n".join(lines)
+
+
+def _format_raw_response(entry: "ProxyEntry") -> str:
+    """Format a ProxyEntry's response as raw HTTP text (reusable by any caller)."""
+    status = entry.response_status or 0
+    lines = [f"HTTP/1.1 {status}"]
+    for k, v in (entry.response_headers or {}).items():
+        if k.lower() == "set-cookie" and isinstance(v, list):
+            for cookie in v:
+                lines.append(f"set-cookie: {cookie}")
+        else:
+            lines.append(f"{k}: {v}")
+    lines.append("")
+    if entry.response_body:
+        lines.append(entry.response_body.decode("utf-8", errors="replace")[:4000])
+    return "\r\n".join(lines)

--- a/dast/proxy/service_graph.py
+++ b/dast/proxy/service_graph.py
@@ -15,24 +15,22 @@ Thread-safe. All mutating operations hold _lock.
 
 from __future__ import annotations
 
-import base64
-import json
 import threading
 import uuid
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Set
 
+from dast.utils.jwt import decode_segment
+
 
 # ── JWT helpers ──────────────────────────────────────────────────────────────
 
 def _decode_jwt_claims(token: str) -> Optional[dict]:
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
     try:
-        parts = token.split(".")
-        if len(parts) != 3:
-            return None
-        padding = 4 - len(parts[1]) % 4
-        payload = base64.urlsafe_b64decode(parts[1] + "=" * padding)
-        return json.loads(payload)
+        return decode_segment(parts[1])
     except Exception:
         return None
 

--- a/dast/proxy/session_store.py
+++ b/dast/proxy/session_store.py
@@ -16,41 +16,15 @@ from urllib.parse import urlparse
 
 from dast.proxy.service_graph import ServiceGraph
 from dast.discovery.engine import DiscoveryEngine
+# Re-exported for backward compatibility: raw HTTP evidence formatting now lives
+# in dast.proxy.http_format. Existing callers still import these names from here.
+from dast.proxy.http_format import _format_raw_request, _format_raw_response
+from dast.proxy.signalr import SIGNALR_SEPARATOR, is_signalr_binary, read_varint
 from dast.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-
-def _format_raw_request(entry: "ProxyEntry") -> str:
-    """Format a ProxyEntry's request as raw HTTP text (reusable by any caller)."""
-    parsed = urlparse(entry.url)
-    path = (parsed.path or "/") + (f"?{parsed.query}" if parsed.query else "")
-    lines = [f"{entry.method} {path} HTTP/1.1", f"Host: {entry.host}"]
-    for k, v in (entry.request_headers or {}).items():
-        if k.lower() != "host":
-            lines.append(f"{k}: {v}")
-    lines.append("")
-    if entry.request_body:
-        lines.append(entry.request_body.decode("utf-8", errors="replace"))
-    return "\r\n".join(lines)
-
-
-def _format_raw_response(entry: "ProxyEntry") -> str:
-    """Format a ProxyEntry's response as raw HTTP text (reusable by any caller)."""
-    status = entry.response_status or 0
-    lines = [f"HTTP/1.1 {status}"]
-    for k, v in (entry.response_headers or {}).items():
-        if k.lower() == "set-cookie" and isinstance(v, list):
-            for cookie in v:
-                lines.append(f"set-cookie: {cookie}")
-        else:
-            lines.append(f"{k}: {v}")
-    lines.append("")
-    if entry.response_body:
-        lines.append(entry.response_body.decode("utf-8", errors="replace")[:4000])
-    return "\r\n".join(lines)
-
-_SIGNALR_SEP = "\x1e"
+_SIGNALR_SEP = SIGNALR_SEPARATOR
 
 
 def _annotate_blazor_args(target: str, args) -> str:
@@ -122,15 +96,7 @@ def _decode_msgpack_signalr(raw: bytes) -> str:
     except ImportError:
         return ""
 
-    def _read_varint(data: bytes, pos: int):
-        result, shift = 0, 0
-        while pos < len(data):
-            b = data[pos]; pos += 1
-            result |= (b & 0x7f) << shift
-            if not (b & 0x80):
-                return result, pos
-            shift += 7
-        return result, pos
+    _read_varint = read_varint
 
     def _unpack(payload: bytes):
         return _mp.unpackb(payload, raw=False, strict_map_key=False)
@@ -292,29 +258,7 @@ def _decode_signalr_body(raw: bytes) -> str:
     return ""
 
 
-def _is_signalr_binary(raw: bytes) -> bool:
-    """
-    Return True if this looks like SignalR binary (MessagePack) protocol.
-
-    SignalR binary frames: <varint-length><msgpack-fixarray>...
-    The varint can be 1-5 bytes (continuation bit 0x80 set on all but the last).
-    We skip varint bytes until we find one without 0x80, then check the next byte
-    is a msgpack fixarray (0x90-0x9f).
-    """
-    if len(raw) < 2:
-        return False
-    # Skip varint bytes (up to 5)
-    pos = 0
-    for _ in range(5):
-        if pos >= len(raw):
-            return False
-        b = raw[pos]; pos += 1
-        if not (b & 0x80):  # last varint byte
-            break
-    # pos now points to first byte after varint — should be msgpack fixarray
-    if pos < len(raw) and 0x90 <= raw[pos] <= 0x9f:
-        return True
-    return False
+_is_signalr_binary = is_signalr_binary
 
 
 def _is_signalr_body(raw: bytes) -> bool:

--- a/dast/proxy/signalr.py
+++ b/dast/proxy/signalr.py
@@ -1,0 +1,68 @@
+"""
+Low-level SignalR / Blazor (blazorpack) wire primitives.
+
+Single home for the framing pieces that were previously copy-pasted across
+`session_store`, `blazor_agent`, and `blazor_detector`: the record separator,
+the msgpack varint length prefix (read + write), and the binary-protocol sniff.
+
+Higher-level decoding stays with each caller because the output shapes differ
+(human-readable strings for the history view vs. structured dicts for the
+detector vs. frame building for the active agent). This module only holds the
+byte-level primitives they all share.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+# SignalR text-protocol record separator (0x1e), between JSON messages.
+SIGNALR_SEPARATOR = "\x1e"
+
+# DOS/PE "MZ" magic — used to spot a leaked native image in Blazor responses.
+MZ_HEADER = b"\x4d\x5a"
+
+
+def read_varint(data: bytes, pos: int) -> Tuple[int, int]:
+    """Read a 7-bit little-endian varint at `pos`; return (value, new_pos)."""
+    result, shift = 0, 0
+    while pos < len(data):
+        byte = data[pos]
+        pos += 1
+        result |= (byte & 0x7F) << shift
+        if not (byte & 0x80):
+            return result, pos
+        shift += 7
+    return result, pos
+
+
+def encode_varint(length: int) -> bytes:
+    """Encode a length as a 7-bit little-endian varint (inverse of read_varint)."""
+    varint = b""
+    while True:
+        byte = length & 0x7F
+        length >>= 7
+        varint += bytes([byte | (0x80 if length else 0)])
+        if not length:
+            break
+    return varint
+
+
+def is_signalr_binary(raw: bytes) -> bool:
+    """
+    Return True if `raw` looks like SignalR binary (MessagePack/blazorpack).
+
+    Binary frames are <varint-length><msgpack-fixarray>...; the varint can be
+    1-5 bytes (continuation bit 0x80 set on all but the last). Skip the varint
+    bytes, then check the next byte is a msgpack fixarray (0x90-0x9f).
+    """
+    if len(raw) < 2:
+        return False
+    pos = 0
+    for _ in range(5):
+        if pos >= len(raw):
+            return False
+        byte = raw[pos]
+        pos += 1
+        if not (byte & 0x80):  # last varint byte
+            break
+    return pos < len(raw) and 0x90 <= raw[pos] <= 0x9F

--- a/dast/utils/jwt.py
+++ b/dast/utils/jwt.py
@@ -1,0 +1,89 @@
+"""
+JWT and base64url helpers — single home for the hand-rolled JWT logic that was
+previously reimplemented across the JWT plugins, the business-logic agent, and
+the service graph.
+
+No external PyJWT dependency: encoding is plain base64url over stdlib `base64`,
+signing uses stdlib `hmac`/`hashlib`. Callers that only need a segment decoded
+use `b64url_decode`; callers that want the parsed header/payload use
+`decode_jwt`; token construction (alg:none or HMAC) uses `build_token`.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from typing import Optional, Tuple
+
+# HMAC algorithms supported by build_token; anything else falls back to SHA-256.
+_HMAC_HASHES = {"HS256": hashlib.sha256, "HS384": hashlib.sha384, "HS512": hashlib.sha512}
+
+
+def b64url_decode(segment: str) -> bytes:
+    """Decode a base64url segment to raw bytes, tolerating missing padding."""
+    padded = segment + "=" * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(padded)
+
+
+def b64url_encode(data: bytes) -> str:
+    """Encode raw bytes as base64url with padding stripped (JWT segment form)."""
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode()
+
+
+def b64url_encode_json(data: dict) -> str:
+    """Encode a dict as a compact JSON base64url segment (JWT header/payload)."""
+    return b64url_encode(json.dumps(data, separators=(",", ":")).encode())
+
+
+def decode_segment(segment: str) -> dict:
+    """Decode a single base64url JWT segment to its parsed JSON object."""
+    return json.loads(b64url_decode(segment))
+
+
+def decode_jwt(token: str) -> Optional[Tuple[dict, dict]]:
+    """Return (header, payload) for a well-formed 3-part JWT, else None."""
+    parts = token.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        return decode_segment(parts[0]), decode_segment(parts[1])
+    except Exception:
+        return None
+
+
+def decode_jwt_header(token: str) -> Optional[dict]:
+    """Return the decoded JWT header (first segment), or None on failure."""
+    parts = token.split(".")
+    if not parts or not parts[0]:
+        return None
+    try:
+        return decode_segment(parts[0])
+    except Exception:
+        return None
+
+
+def decode_jwt_claims(token: str) -> Optional[dict]:
+    """Return the decoded JWT payload claims (second segment), or None."""
+    parts = token.split(".")
+    if len(parts) < 2:
+        return None
+    try:
+        return decode_segment(parts[1])
+    except Exception:
+        return None
+
+
+def build_token(header: dict, payload: dict, secret: Optional[str] = None) -> str:
+    """Build a JWT. secret=None yields an unsigned (alg:none) token with an
+    empty signature; otherwise HMAC-sign using the algorithm in the header."""
+    encoded_header = b64url_encode_json(header)
+    encoded_payload = b64url_encode_json(payload)
+    signing_input = f"{encoded_header}.{encoded_payload}".encode()
+    if secret is None:
+        signature = ""
+    else:
+        hash_fn = _HMAC_HASHES.get(header.get("alg", "HS256"), hashlib.sha256)
+        signature = b64url_encode(hmac.new(secret.encode(), signing_input, hash_fn).digest())
+    return f"{encoded_header}.{encoded_payload}.{signature}"


### PR DESCRIPTION
## Phase 2 — consolidate duplicated helpers

Behavior-preserving. Extracts logic that was copy-pasted across modules into single-owner homes; existing callers keep their public names via thin aliases, so the blast radius is minimal.

### New modules
- **`dast/utils/jwt.py`** — base64url + JWT decode/encode/build. Replaces 4 hand-rolled copies (`jwt_tester`, `jwt_analyzer`, `business_logic_agent`, `service_graph`). Standardizes on the `-len % 4` padding idiom + `urlsafe_b64decode`.
- **`dast/proxy/signalr.py`** — SignalR/blazorpack wire primitives: record separator, MZ header, varint read/write, binary sniff. Replaces copies in `session_store`, `blazor_agent`, `blazor_detector`. Higher-level decoders stay per-file (different output shapes: strings vs dicts vs frame-building).
- **`dast/proxy/http_format.py`** — raw HTTP request/response evidence formatting, moved out of `session_store`; `passive_scanner` repointed to it.

### Not merged (intentionally left per-caller)
- `hackerone/validator._validate_http` inline formatting (LF not CRLF, different truncation limits) — different behavior, out of scope.
- `active_checks._fmt_http_pair` (httpx.Response source, full-URL request line) — different signature; kept as-is.

### Verification
- `uv run pytest` → **1273 passed**
- `uv run ruff check .` → clean
- import smoke check passes
- no leftover `_read_varint` / manual `urlsafe_b64*` outside the new util modules

No logic changes.