### PR TITLE
feat(ui): unify Vuln Validator panel + improve Decoder usability

### DIFF
--- a/dast/proxy/ui/index.html
+++ b/dast/proxy/ui/index.html
@@ -1721,13 +1721,13 @@
         <div style="padding:12px 14px;border-bottom:1px solid var(--bdr);flex-shrink:0;overflow-y:auto">
           <div style="font-size:11px;font-weight:600;color:var(--acc2);margin-bottom:10px;text-transform:uppercase;letter-spacing:.5px">Vuln Validator</div>
 
-          <!-- Manual (single-shot) vs AI (agentic reproduction) mode -->
-          <div style="display:flex;gap:0;margin-bottom:10px;border:1px solid var(--bdr);border-radius:4px;overflow:hidden">
-            <button id="vv-mode-manual" class="tbtn" onclick="vvSetMode('manual')"
-                    style="flex:1;border:none;border-radius:0;font-size:10px;padding:6px 8px">Manual</button>
-            <button id="vv-mode-ai" class="tbtn" onclick="vvSetMode('ai')"
-                    style="flex:1;border:none;border-radius:0;border-left:1px solid var(--bdr);font-size:10px;padding:6px 8px">AI (agentic)</button>
-          </div>
+          <!-- AI agentic validation is an opt-in; unchecked runs a single-shot validation. -->
+          <label id="vv-ai-toggle" style="display:flex;align-items:center;gap:8px;margin-bottom:8px;
+                 cursor:pointer;user-select:none;font-size:11px;color:var(--txt)">
+            <input type="checkbox" id="vv-use-ai" onchange="vvSetMode(this.checked ? 'ai' : 'manual')"
+                   style="cursor:pointer;margin:0">
+            <span>Use AI agentic reproduction</span>
+          </label>
           <div id="vv-mode-hint" style="font-size:10px;color:var(--txt2);margin-bottom:10px;line-height:1.4">
             Single-shot reproduction: parse the report and validate it once.
           </div>
@@ -2000,7 +2000,11 @@
     <div id="extras-sub-decoder" style="flex:1;overflow:hidden;display:none">
       <div style="flex:1;display:flex;flex-direction:column;overflow:hidden;border-right:1px solid var(--bdr)">
         <div style="padding:8px 14px;font-size:10px;font-weight:600;color:var(--acc2);
-                    text-transform:uppercase;letter-spacing:.5px;border-bottom:1px solid var(--bdr)">Input</div>
+                    text-transform:uppercase;letter-spacing:.5px;border-bottom:1px solid var(--bdr);
+                    display:flex;align-items:center;gap:8px">
+          <span style="flex:1">Input</span>
+          <span id="dec-in-len" style="font-weight:400;color:var(--txt2);text-transform:none;letter-spacing:0"></span>
+        </div>
         <textarea id="dec-input" oninput="decoderRun()"
           placeholder="Paste text to encode/decode..."
           style="flex:1;width:100%;background:var(--bg);border:none;color:var(--txt);box-sizing:border-box;
@@ -2017,6 +2021,9 @@
                     text-transform:uppercase;letter-spacing:.5px;border-bottom:1px solid var(--bdr);
                     display:flex;align-items:center;gap:8px">
           <span style="flex:1">Output</span>
+          <span id="dec-out-len" style="font-weight:400;color:var(--txt2);text-transform:none;letter-spacing:0"></span>
+          <button class="tbtn" style="font-size:9px;padding:1px 7px" onclick="decoderUseOutputAsInput()"
+                  title="Feed the output back into the input to chain transforms">Use as input</button>
           <button class="tbtn" style="font-size:9px;padding:1px 7px" onclick="decoderCopy()">Copy</button>
         </div>
         <pre id="dec-output" style="flex:1;overflow:auto;margin:0;padding:10px 14px;

--- a/dast/proxy/ui/js/76-extras-decoder-jwt.js
+++ b/dast/proxy/ui/js/76-extras-decoder-jwt.js
@@ -1,19 +1,21 @@
 // ── Decoder / Encoder — client-side transform toolbelt ──────────────────
 // All transforms run in the browser; no request ever leaves the page.
 
+// Ops are grouped by family so the encode/decode pair for each codec sits together
+// in the picker instead of being scattered across one flat list.
 const _DECODER_OPS = [
-  { id: 'b64-enc',   label: 'Base64 encode',  fn: s => _b64encode(s) },
-  { id: 'b64-dec',   label: 'Base64 decode',  fn: s => _b64decode(s) },
-  { id: 'b64url-enc',label: 'Base64URL encode',fn: s => _b64encode(s).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'') },
-  { id: 'b64url-dec',label: 'Base64URL decode',fn: s => _b64decode(_b64urlPad(s.replace(/-/g,'+').replace(/_/g,'/'))) },
-  { id: 'url-enc',   label: 'URL encode',     fn: s => encodeURIComponent(s) },
-  { id: 'url-dec',   label: 'URL decode',     fn: s => decodeURIComponent(s.replace(/\+/g,' ')) },
-  { id: 'url-enc-all',label:'URL encode (all)',fn: s => Array.from(s).map(c => '%' + c.charCodeAt(0).toString(16).padStart(2,'0').toUpperCase()).join('') },
-  { id: 'html-enc',  label: 'HTML encode',    fn: s => s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;') },
-  { id: 'html-dec',  label: 'HTML decode',    fn: s => _htmlDecode(s) },
-  { id: 'hex-enc',   label: 'Hex encode',     fn: s => Array.from(new TextEncoder().encode(s)).map(b => b.toString(16).padStart(2,'0')).join('') },
-  { id: 'hex-dec',   label: 'Hex decode',     fn: s => _hexDecode(s) },
-  { id: 'jwt-dec',   label: 'JWT decode',     fn: s => _jwtDecodeText(s) },
+  { id: 'b64-enc',    group: 'Base64',    label: 'Encode',            fn: s => _b64encode(s) },
+  { id: 'b64-dec',    group: 'Base64',    label: 'Decode',            fn: s => _b64decode(s) },
+  { id: 'b64url-enc', group: 'Base64URL', label: 'Encode',            fn: s => _b64encode(s).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'') },
+  { id: 'b64url-dec', group: 'Base64URL', label: 'Decode',            fn: s => _b64decode(_b64urlPad(s.replace(/-/g,'+').replace(/_/g,'/'))) },
+  { id: 'url-enc',    group: 'URL',       label: 'Encode',            fn: s => encodeURIComponent(s) },
+  { id: 'url-dec',    group: 'URL',       label: 'Decode',            fn: s => decodeURIComponent(s.replace(/\+/g,' ')) },
+  { id: 'url-enc-all',group: 'URL',       label: 'Encode (all chars)',fn: s => Array.from(s).map(c => '%' + c.charCodeAt(0).toString(16).padStart(2,'0').toUpperCase()).join('') },
+  { id: 'html-enc',   group: 'HTML',      label: 'Encode',            fn: s => s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;') },
+  { id: 'html-dec',   group: 'HTML',      label: 'Decode',            fn: s => _htmlDecode(s) },
+  { id: 'hex-enc',    group: 'Hex',       label: 'Encode',            fn: s => Array.from(new TextEncoder().encode(s)).map(b => b.toString(16).padStart(2,'0')).join('') },
+  { id: 'hex-dec',    group: 'Hex',       label: 'Decode',            fn: s => _hexDecode(s) },
+  { id: 'jwt-dec',    group: 'JWT',       label: 'Decode',            fn: s => _jwtDecodeText(s) },
 ];
 
 let _decoderOp = 'b64-dec';
@@ -50,9 +52,20 @@ function _jwtDecodeText(s) {
 function decoderInit() {
   const ops = document.getElementById('dec-ops');
   if (ops && !ops.dataset.built) {
-    ops.innerHTML = _DECODER_OPS.map(op =>
-      `<div class="dec-op" id="dec-op-${op.id}" onclick="decoderPick('${op.id}')"
-            style="padding:5px 14px;font-size:11px;cursor:pointer;color:var(--txt)">${op.label}</div>`
+    const groups = [];
+    _DECODER_OPS.forEach(op => {
+      let g = groups.find(x => x.name === op.group);
+      if (!g) { g = { name: op.group, ops: [] }; groups.push(g); }
+      g.ops.push(op);
+    });
+    ops.innerHTML = groups.map(g =>
+      `<div class="dec-group">` +
+        `<div style="padding:9px 14px 3px;font-size:9px;font-weight:600;color:var(--txt2);` +
+             `text-transform:uppercase;letter-spacing:.5px">${g.name}</div>` +
+        g.ops.map(op =>
+          `<div class="dec-op" id="dec-op-${op.id}" onclick="decoderPick('${op.id}')">${op.label}</div>`
+        ).join('') +
+      `</div>`
     ).join('');
     ops.dataset.built = '1';
   }
@@ -63,7 +76,7 @@ function decoderPick(id) {
   _decoderOp = id;
   _DECODER_OPS.forEach(op => {
     const el = document.getElementById('dec-op-' + op.id);
-    if (el) el.style.background = op.id === id ? 'var(--bg3)' : 'transparent';
+    if (el) el.classList.toggle('on', op.id === id);
   });
   decoderRun();
 }
@@ -78,23 +91,39 @@ function _decoderFriendlyError(op) {
 }
 
 function decoderRun() {
-  const input  = document.getElementById('dec-input').value;
-  const out     = document.getElementById('dec-output');
-  const op      = _DECODER_OPS.find(o => o.id === _decoderOp);
+  const input   = document.getElementById('dec-input').value;
+  const out      = document.getElementById('dec-output');
+  const op        = _DECODER_OPS.find(o => o.id === _decoderOp);
+  const inLen    = document.getElementById('dec-in-len');
+  const outLen  = document.getElementById('dec-out-len');
+  if (inLen) inLen.textContent = input ? input.length + ' chars' : '';
   if (!op) return;
-  if (!input) { out.textContent = ''; out.style.color = 'var(--txt2)'; return; }
+  if (!input) { out.textContent = ''; out.style.color = 'var(--txt2)'; if (outLen) outLen.textContent = ''; return; }
   try {
-    out.textContent = op.fn(input);
+    const result = op.fn(input);
+    out.textContent = result;
     out.style.color = 'var(--orange)';
+    if (outLen) outLen.textContent = result.length + ' chars';
   } catch (e) {
     out.textContent = _decoderFriendlyError(op);
     out.style.color = 'var(--txt2)';
+    if (outLen) outLen.textContent = '';
   }
 }
 
 function decoderCopy() {
   const out = document.getElementById('dec-output').textContent;
   if (out) navigator.clipboard.writeText(out).then(() => showToast('Copied output'));
+}
+
+// Feed the current output back into the input to chain transforms
+// (e.g. URL decode then Base64 decode).
+function decoderUseOutputAsInput() {
+  const out = document.getElementById('dec-output').textContent;
+  const inp = document.getElementById('dec-input');
+  if (!out || !inp) return;
+  inp.value = out;
+  decoderRun();
 }
 
 // ── JWT editor — decode, edit, re-sign, send to Repeater ─────────────────

--- a/dast/proxy/ui/js/91-vuln-validator.js
+++ b/dast/proxy/ui/js/91-vuln-validator.js
@@ -15,11 +15,9 @@ function vvSetMode(mode) {
   _vvMode = mode === 'ai' ? 'ai' : 'manual';
   const isAi = _vvMode === 'ai';
 
-  // Toggle the segmented control's active button.
-  const mBtn = document.getElementById('vv-mode-manual');
-  const aBtn = document.getElementById('vv-mode-ai');
-  if (mBtn) mBtn.classList.toggle('pri', !isAi);
-  if (aBtn) aBtn.classList.toggle('pri', isAi);
+  // Keep the opt-in checkbox in sync (vvSetMode may be called programmatically).
+  const cb = document.getElementById('vv-use-ai');
+  if (cb) cb.checked = isAi;
 
   // Swap the right-hand panel and hide manual-only inputs in AI mode.
   const manualResult = document.getElementById('vv-manual-result');
@@ -412,9 +410,9 @@ function vvEnsurePulse() {
   document.head.appendChild(s);
 }
 
-// Default the segmented control to Manual on load. This script is included near
-// the end of <body>, so DOMContentLoaded may already have fired — apply directly
-// in that case, otherwise wait for it.
+// Default to single-shot (AI opt-in unchecked) on load. This script is included
+// near the end of <body>, so DOMContentLoaded may already have fired — apply
+// directly in that case, otherwise wait for it.
 if (document.readyState === 'loading') {
   document.addEventListener('DOMContentLoaded', () => vvSetMode('manual'));
 } else {

--- a/dast/proxy/ui/styles.css
+++ b/dast/proxy/ui/styles.css
@@ -62,6 +62,11 @@ html, body { height: 100%; font: 12px/1.4 -apple-system, BlinkMacSystemFont, 'Se
 .stab:hover { color: var(--txt); background: var(--bg4); }
 .stab.on { background: var(--bg4); color: var(--txt); }
 
+/* DECODER transform picker */
+.dec-op { padding: 5px 20px; font-size: 11px; cursor: pointer; color: var(--txt); user-select: none; }
+.dec-op:hover { background: var(--bg4); }
+.dec-op.on { background: var(--bg3); color: var(--orange); }
+
 /* WORKSPACE */
 #workspace { display: flex; height: calc(100vh - 70px); overflow: hidden; }
 .tpanel { display: none; flex: 1; flex-direction: column; overflow: hidden; }


### PR DESCRIPTION
## Summary
Two UX fixes based on dashboard feedback.

### Vuln Validator — one panel, AI is an opt-in
The Manual / AI (agentic) segmented toggle read like two separate tabs. Replaced it with a single form and an **"Use AI agentic reproduction"** checkbox. Unchecked runs the single-shot validation; checked runs the agentic path. Dispatch still happens on the mode in `vvValidate()`/`vvLoadJobs()`, so both backends (`/api/h1/*` and `/api/vuln-validator/*`) are untouched — only the surface is simplified.

### Decoder — better usability
- Transform picker is now grouped by codec family (Base64, Base64URL, URL, HTML, Hex, JWT) so each encode/decode pair sits together instead of a flat 12-item list.
- New **"Use as input"** action feeds the output back into the input to chain transforms (e.g. URL-decode then Base64-decode).
- Input/output **character counts** shown in the headers.
- Picker styling moved to a `.dec-op` CSS rule with hover + selected states.

## Scope
Frontend only (`index.html`, `js/91-vuln-validator.js`, `js/76-extras-decoder-jwt.js`, `styles.css`). No Python touched. `scripts/lint_ui.js` passes.