### PR TITLE
feat(chains): multi-step attack-chain validation engine + validate_chain tool

### DIFF
--- a/dast/ai/schemas.py
+++ b/dast/ai/schemas.py
@@ -274,3 +274,71 @@ PROBE_CLASSIFIER_SCHEMA: Dict[str, Any] = {
     },
     "required": ["injection_class", "context", "confidence", "recommended_agents", "reasoning"],
 }
+
+# Attack-chain planner — dast/chains/planner.py plan_chain().
+# Turns a free-text multi-step report into an executable chain spec. The step
+# fields mirror dast/chains/models.py (ChainStep/Extractor/Assertion) so the
+# planner output feeds ChainEngine.run() directly.
+ATTACK_CHAIN_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "name": {"type": "string", "description": "Short slug for the chain, e.g. 'guest-token-cdn-access'."},
+        "description": {"type": "string", "description": "One sentence: what the chain proves and why it is a vulnerability."},
+        "vuln_type": {
+            "type": "string",
+            "description": "Best-fit category: broken_access_control, business_logic, auth_bypass, idor, info_disclosure, or attack_chain if none fit.",
+        },
+        "steps": {
+            "type": "array",
+            "description": "Ordered requests. Earlier steps bind variables/cookies that later steps consume via {{var}} templates. Include a final CONTROL step (send_cookies:[] or without the key credential) that is expected to FAIL, proving the credential is what defeats the check.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Human label for the step, e.g. 'bootstrap' or 'control-no-cookies'."},
+                    "method": {"type": "string", "description": "HTTP method. Default GET."},
+                    "url": {"type": "string", "description": "Absolute URL on the target host. May contain {{var}} placeholders bound by earlier steps."},
+                    "headers": {"type": "object", "additionalProperties": {"type": "string"}, "description": "Request headers; may use {{var}} (e.g. Authorization: Bearer {{jwt}})."},
+                    "body": {"type": "string", "description": "Request body for POST/PUT (e.g. a GraphQL query). May use {{var}}. Empty otherwise."},
+                    "send_cookies": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Cookie names to send. Omit to send all harvested cookies; use an EMPTY array for a control step that must send none.",
+                    },
+                    "max_range_bytes": {"type": "integer", "description": "When fetching content, cap the response to this many bytes (adds a Range header) so validation never pulls a full asset. Use a small value like 64."},
+                    "extract": {
+                        "type": "array",
+                        "description": "Bind data out of this step's response for later steps.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "kind": {"type": "string", "description": "json | regex | set_cookie | b64json | jwt_claim."},
+                                "var": {"type": "string", "description": "Variable name to bind."},
+                                "expr": {"type": "string", "description": "json/b64json/jwt_claim: dotted path (key, key[0], key[*]). regex: pattern (group 1 wins). set_cookie: cookie name."},
+                                "from": {"type": "string", "description": "Source: body (default), header:<Name>, or var:<name>."},
+                            },
+                            "required": ["kind", "var"],
+                        },
+                    },
+                    "assertions": {
+                        "type": "array",
+                        "description": "Conditions that must hold for the step to pass.",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "kind": {"type": "string", "description": "status_eq | status_in | header_contains | body_contains | body_not_contains | var_present | var_contains | var_equals."},
+                                "value": {"description": "Operand for status_eq / var_equals."},
+                                "values": {"type": "array", "description": "Operand for status_in."},
+                                "name": {"type": "string", "description": "Header name for header_contains."},
+                                "needle": {"type": "string", "description": "Substring for *_contains."},
+                                "var": {"type": "string", "description": "Variable name for var_* assertions."},
+                            },
+                            "required": ["kind"],
+                        },
+                    },
+                },
+                "required": ["name", "url"],
+            },
+        },
+    },
+    "required": ["name", "vuln_type", "steps"],
+}

--- a/dast/chains/__init__.py
+++ b/dast/chains/__init__.py
@@ -1,0 +1,31 @@
+"""
+Attack-chain validation.
+
+A single-request validator cannot confirm a multi-step exploit — one where the
+output of request N (a token, a Set-Cookie, an unguessable path leaked by a
+GraphQL field) is what makes request N+1 succeed. This package models such a
+chain as a data-driven sequence of steps with per-step extractors (bind data
+out of a response) and assertions (what must hold), runs it through the proxy
+under the same scope + payload-safety gates as every other Frieren request, and
+returns a step-by-step verdict.
+
+See ``engine.py`` for the executor and ``models.py`` for the chain spec.
+"""
+
+from dast.chains.models import (
+    Assertion,
+    Chain,
+    ChainResult,
+    ChainStep,
+    Extractor,
+    StepResult,
+)
+
+__all__ = [
+    "Assertion",
+    "Chain",
+    "ChainResult",
+    "ChainStep",
+    "Extractor",
+    "StepResult",
+]

--- a/dast/chains/engine.py
+++ b/dast/chains/engine.py
@@ -1,0 +1,335 @@
+"""
+Attack-chain executor.
+
+Runs a :class:`Chain` step by step, threading variables and cookies from one
+response into the next request. Every step is scope-gated and payload-safety
+gated exactly like ``tools.http_tools.send_request`` — the chain is not a way
+around Frieren's safety model, it composes it.
+
+The sender is injected (``sender`` argument) so the engine is fully testable
+offline; the default sender routes through the running proxy with httpx.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import re
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple
+
+from dast.chains.models import (
+    Assertion,
+    Chain,
+    ChainResult,
+    ChainStep,
+    Extractor,
+    StepResult,
+)
+from dast.hackerone import payload_safety
+from dast.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# sender(method, url, headers, body) -> (status, response_headers, response_text)
+Sender = Callable[[str, str, Dict[str, str], str], Awaitable[Tuple[int, Dict[str, str], str]]]
+
+_MAX_BODY_CAPTURE = 16000
+_TEMPLATE = re.compile(r"\{\{\s*([a-zA-Z0-9_]+)\s*\}\}")
+_SENSITIVE = re.compile(r"(jwt|token|cookie|signature|policy|secret|key|bearer|auth)", re.I)
+
+
+def _redact(var: str, value: str) -> str:
+    """Redact a bound value for reporting: never emit a full token/cookie."""
+    text = value if isinstance(value, str) else json.dumps(value)
+    if _SENSITIVE.search(var) or len(text) > 40:
+        preview = text[:8]
+        return f"{var}=<{len(text)} chars, starts {preview!r}>"
+    return f"{var}={text}"
+
+
+def _b64json(raw: str) -> object:
+    """base64url-decode (padding-tolerant) and JSON-parse."""
+    s = raw.strip().replace("-", "+").replace("_", "/")
+    s += "=" * (-len(s) % 4)
+    return json.loads(base64.b64decode(s))
+
+
+def _json_path(obj: object, expr: str) -> List[object]:
+    """Resolve a dotted path with ``key``, ``key[0]`` and ``key[*]`` support.
+
+    Returns a flat list of every match (empty when nothing matches).
+    """
+    current: List[object] = [obj]
+    if not expr:
+        return current
+    for token in expr.split("."):
+        key, indices = token, []
+        # Peel trailing [..] selectors off the token.
+        for m in re.finditer(r"\[([0-9*]+)\]", token):
+            indices.append(m.group(1))
+        key = re.sub(r"\[[0-9*]+\]", "", token)
+        nxt: List[object] = []
+        for node in current:
+            value = node
+            if key:
+                if isinstance(node, dict) and key in node:
+                    value = node[key]
+                else:
+                    continue
+            for sel in indices:
+                if sel == "*":
+                    if isinstance(value, list):
+                        nxt.extend(value)
+                    value = _CONSUMED
+                    break
+                else:
+                    idx = int(sel)
+                    if isinstance(value, list) and -len(value) <= idx < len(value):
+                        value = value[idx]
+                    else:
+                        value = _CONSUMED
+                        break
+            if value is not _CONSUMED:
+                nxt.append(value)
+        current = nxt
+    return current
+
+
+_CONSUMED = object()
+
+
+def _parse_set_cookies(headers: Dict[str, str]) -> Dict[str, str]:
+    """Harvest name=value pairs from a response's Set-Cookie header(s).
+
+    httpx joins repeated Set-Cookie headers with commas; split conservatively on
+    the ``name=`` boundary that follows a ``; `` so cookie values (which may
+    contain commas) survive.
+    """
+    raw = ""
+    for k, v in headers.items():
+        if k.lower() == "set-cookie":
+            raw = v
+            break
+    if not raw:
+        return {}
+    jar: Dict[str, str] = {}
+    # Split into individual cookies: a new cookie starts after ", <token>=".
+    parts = re.split(r",\s*(?=[A-Za-z0-9!#$%&'*+\-.^_`|~]+=)", raw)
+    for part in parts:
+        first = part.split(";", 1)[0].strip()
+        if "=" in first:
+            name, _, value = first.partition("=")
+            jar[name.strip()] = value.strip()
+    return jar
+
+
+def _render(text: str, variables: Dict[str, str]) -> str:
+    return _TEMPLATE.sub(lambda m: str(variables.get(m.group(1), m.group(0))), text)
+
+
+def _resolve_source(source: str, body: str, headers: Dict[str, str],
+                    variables: Dict[str, str]) -> str:
+    if source == "body":
+        return body
+    if source.startswith("header:"):
+        want = source.split(":", 1)[1].strip().lower()
+        for k, v in headers.items():
+            if k.lower() == want:
+                return v
+        return ""
+    if source.startswith("var:"):
+        return variables.get(source.split(":", 1)[1].strip(), "")
+    return body
+
+
+def _apply_extractor(ext: Extractor, body: str, headers: Dict[str, str],
+                     variables: Dict[str, str], jar: Dict[str, str]) -> Optional[str]:
+    """Run one extractor; return the bound value (also written into ``variables``)."""
+    try:
+        if ext.kind == "set_cookie":
+            value = jar.get(ext.expr, "")
+        else:
+            source_text = _resolve_source(ext.source, body, headers, variables)
+            if ext.kind == "regex":
+                m = re.search(ext.expr, source_text)
+                value = (m.group(1) if m and m.groups() else (m.group(0) if m else "")) or ""
+            elif ext.kind == "json":
+                matches = _json_path(json.loads(source_text), ext.expr)
+                value = matches[0] if matches else ""
+                variables[f"{ext.var}__count"] = str(len(matches))
+            elif ext.kind == "b64json":
+                matches = _json_path(_b64json(source_text), ext.expr)
+                value = matches[0] if matches else ""
+            elif ext.kind == "jwt_claim":
+                payload = source_text.split(".")[1] if source_text.count(".") >= 2 else source_text
+                matches = _json_path(_b64json(payload), ext.expr)
+                value = matches[0] if matches else ""
+            else:
+                logger.warning("unknown extractor kind", kind=ext.kind, var=ext.var)
+                return None
+        if not isinstance(value, str):
+            value = json.dumps(value)
+        variables[ext.var] = value
+        return value
+    except (ValueError, KeyError, IndexError, json.JSONDecodeError, binascii.Error) as exc:
+        logger.debug("extractor failed", kind=ext.kind, var=ext.var, error=str(exc))
+        return None
+
+
+def _check_assertion(a: Assertion, status: Optional[int], body: str,
+                     headers: Dict[str, str], variables: Dict[str, str]) -> Tuple[bool, str]:
+    """Evaluate one assertion; return (passed, human-readable result)."""
+    label = a.kind
+    try:
+        if a.kind == "status_eq":
+            ok = status == int(a.value)
+            return ok, f"status_eq {a.value}: got {status}"
+        if a.kind == "status_in":
+            wanted = [int(v) for v in a.values]
+            return status in wanted, f"status_in {wanted}: got {status}"
+        if a.kind == "header_contains":
+            got = next((v for k, v in headers.items() if k.lower() == a.name.lower()), "")
+            return a.needle.lower() in got.lower(), f"header {a.name!r} contains {a.needle!r}: {a.needle.lower() in got.lower()}"
+        if a.kind == "body_contains":
+            return a.needle in body, f"body contains {a.needle!r}: {a.needle in body}"
+        if a.kind == "body_not_contains":
+            return a.needle not in body, f"body NOT contains {a.needle!r}: {a.needle not in body}"
+        if a.kind == "var_present":
+            v = variables.get(a.var, "")
+            return bool(v), f"var {a.var!r} present: {bool(v)}"
+        if a.kind == "var_contains":
+            v = variables.get(a.var, "")
+            return a.needle in v, f"var {a.var!r} contains {a.needle!r}: {a.needle in v}"
+        if a.kind == "var_equals":
+            v = variables.get(a.var, "")
+            return v == str(a.value), f"var {a.var!r} equals {a.value!r}: {v == str(a.value)}"
+        return False, f"unknown assertion kind: {a.kind}"
+    except (ValueError, TypeError) as exc:
+        return False, f"{label} error: {exc}"
+
+
+class ChainEngine:
+    """Executes a :class:`Chain`, scope- and safety-gated, sender-injected."""
+
+    def __init__(
+        self,
+        sender: Sender,
+        is_in_scope: Callable[[str], bool],
+        initial_cookies: Optional[Dict[str, str]] = None,
+    ):
+        self._sender = sender
+        self._is_in_scope = is_in_scope
+        self._jar: Dict[str, str] = dict(initial_cookies or {})
+        self._vars: Dict[str, str] = {}
+
+    async def run(self, chain: Chain) -> ChainResult:
+        result = ChainResult(name=chain.name, status="confirmed", vuln_type=chain.vuln_type)
+        for step in chain.steps:
+            step_result = await self._run_step(step)
+            result.steps.append(step_result)
+            if step_result.note in ("out_of_scope", "destructive_refused"):
+                result.status = "blocked"
+                break
+            if step_result.status is None:
+                result.status = "error"
+                break
+            if _looks_like_auth_wall(step_result.status):
+                result.status = "needs_auth"
+                break
+            if not step_result.passed:
+                result.status = "refuted"
+                break
+        result.evidence = _build_evidence(chain, result)
+        logger.info("chain executed", name=chain.name, status=result.status,
+                    steps=len(result.steps))
+        return result
+
+    async def _run_step(self, step: ChainStep) -> StepResult:
+        url = _render(step.url, self._vars)
+        sr = StepResult(name=step.name, method=step.method, url=url)
+
+        # Scope gate BEFORE anything is sent.
+        if not self._is_in_scope(url):
+            sr.note = "out_of_scope"
+            sr.assertion_results.append(f"refused: {url} is out of scope")
+            return sr
+
+        headers = {k: _render(v, self._vars) for k, v in step.headers.items()}
+        body = _render(step.body, self._vars)
+
+        # Payload-safety gate: refuse destructive URL/body.
+        for where, text in (("url", url), ("body", body)):
+            verdict = payload_safety.classify(text)
+            if verdict.is_destructive:
+                sr.note = "destructive_refused"
+                sr.assertion_results.append(f"refused: destructive payload in {where} ({verdict.reason})")
+                return sr
+
+        # Cookie jar → Cookie header (filtered per step).
+        cookie_header = self._cookie_header(step)
+        if cookie_header:
+            headers.setdefault("Cookie", cookie_header)
+        # Safety: cap content pulls so a media/content check never mirrors an asset.
+        if step.max_range_bytes:
+            headers.setdefault("Range", f"bytes=0-{max(0, step.max_range_bytes - 1)}")
+
+        try:
+            status, resp_headers, resp_body = await self._sender(step.method, url, headers, body)
+        except Exception as exc:  # sender failure is not fatal to reporting
+            logger.warning("chain step send failed", step=step.name, url=url[:120], error=str(exc))
+            sr.note = f"send_error: {str(exc)[:120]}"
+            return sr
+
+        resp_body = resp_body[:_MAX_BODY_CAPTURE]
+        sr.status = status
+
+        # Always harvest Set-Cookie so credentials flow to later steps.
+        harvested = _parse_set_cookies(resp_headers)
+        if harvested:
+            self._jar.update(harvested)
+
+        for ext in step.extract:
+            value = _apply_extractor(ext, resp_body, resp_headers, self._vars, harvested or self._jar)
+            if value is not None:
+                sr.extracted.append(_redact(ext.var, value))
+
+        passed = True
+        for a in step.assertions:
+            ok, detail = _check_assertion(a, status, resp_body, resp_headers, self._vars)
+            sr.assertion_results.append(detail)
+            passed = passed and ok
+        # A step with no assertions is a setup step: it passes if it was sent.
+        sr.passed = passed
+        return sr
+
+    def _cookie_header(self, step: ChainStep) -> str:
+        if step.send_cookies is None:
+            items = self._jar.items()
+        elif not step.send_cookies:
+            return ""  # control step: send nothing
+        else:
+            wanted = set(step.send_cookies)
+            items = [(k, v) for k, v in self._jar.items() if k in wanted]
+        return "; ".join(f"{k}={v}" for k, v in items)
+
+
+def _looks_like_auth_wall(status: int) -> bool:
+    return status in (401, 407)
+
+
+def _build_evidence(chain: Chain, result: ChainResult) -> str:
+    lines = [f"Chain '{chain.name}' -> {result.status.upper()}"]
+    if chain.description:
+        lines.append(chain.description)
+    lines.append("")
+    for i, s in enumerate(result.steps, 1):
+        mark = "PASS" if s.passed else ("--" if s.note else "FAIL")
+        lines.append(f"{i}. [{mark}] {s.method} {s.url}  -> {s.status}")
+        for a in s.assertion_results:
+            lines.append(f"      assert: {a}")
+        for e in s.extracted:
+            lines.append(f"      bound:  {e}")
+        if s.note:
+            lines.append(f"      note:   {s.note}")
+    return "\n".join(lines)

--- a/dast/chains/models.py
+++ b/dast/chains/models.py
@@ -1,0 +1,198 @@
+"""
+Data model for an attack chain.
+
+A chain is a JSON-serializable spec so it can be authored by hand, produced by
+the LLM planner (``planner.py``) from a free-text report, or round-tripped over
+MCP. Nothing here performs I/O — execution lives in ``engine.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Extractor:
+    """Bind a value out of a step's response (or an earlier variable) into ``var``.
+
+    kind:
+      json       — source text is JSON; ``expr`` is a dotted path (supports
+                   ``key``, ``key[0]``, ``key[*]`` to collect a list).
+      regex      — ``expr`` is a regex; binds group 1 if present else group 0.
+      set_cookie — ``expr`` is a cookie name; binds its value from Set-Cookie.
+      b64json    — source is base64url; decoded, parsed as JSON, then ``expr``.
+      jwt_claim  — source is a JWT; its payload is decoded, then ``expr`` (json).
+
+    source (``from``):
+      body (default) | header:<Name> | var:<name>
+    """
+
+    kind: str
+    var: str
+    expr: str = ""
+    source: str = "body"
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "Extractor":
+        return Extractor(
+            kind=str(data.get("kind", "")).strip(),
+            var=str(data.get("var", "")).strip(),
+            expr=str(data.get("expr", "")),
+            source=str(data.get("from", data.get("source", "body"))).strip() or "body",
+        )
+
+
+@dataclass
+class Assertion:
+    """A condition that must hold for the step to be considered a pass.
+
+    kind:
+      status_eq / status_in — response status equals / is in ``values``.
+      header_contains        — response header ``name`` contains ``needle``.
+      body_contains / body_not_contains — response body substring test.
+      var_present            — variable ``var`` was bound and is non-empty.
+      var_contains / var_equals — variable ``var`` contains / equals ``value``.
+    """
+
+    kind: str
+    # Generic operands; only the ones relevant to ``kind`` are read.
+    value: Any = None
+    values: List[Any] = field(default_factory=list)
+    name: str = ""
+    needle: str = ""
+    var: str = ""
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "Assertion":
+        return Assertion(
+            kind=str(data.get("kind", "")).strip(),
+            value=data.get("value"),
+            values=list(data.get("values", []) or []),
+            name=str(data.get("name", "")),
+            needle=str(data.get("needle", "")),
+            var=str(data.get("var", "")),
+        )
+
+
+@dataclass
+class ChainStep:
+    """One request in the chain.
+
+    ``url``, ``headers`` and ``body`` may contain ``{{var}}`` placeholders that
+    are substituted from variables bound by earlier steps' extractors.
+
+    send_cookies:
+      None  — send the whole accumulated cookie jar (default).
+      []    — send no cookies (a control step, to prove cookies are what matter).
+      [...] — send only the named cookies.
+
+    max_range_bytes: when set, a ``Range: bytes=0-(n-1)`` header caps the
+    response so a media/content check never pulls the full asset (safety).
+    """
+
+    name: str
+    method: str = "GET"
+    url: str = ""
+    headers: Dict[str, str] = field(default_factory=dict)
+    body: str = ""
+    extract: List[Extractor] = field(default_factory=list)
+    assertions: List[Assertion] = field(default_factory=list)
+    send_cookies: Optional[List[str]] = None
+    max_range_bytes: Optional[int] = None
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "ChainStep":
+        send_cookies = data.get("send_cookies")
+        if send_cookies is not None:
+            send_cookies = [str(c) for c in send_cookies]
+        max_range = data.get("max_range_bytes")
+        return ChainStep(
+            name=str(data.get("name", "")).strip() or "step",
+            method=str(data.get("method", "GET")).upper().strip() or "GET",
+            url=str(data.get("url", "")).strip(),
+            headers={str(k): str(v) for k, v in (data.get("headers") or {}).items()},
+            body=str(data.get("body", "") or ""),
+            extract=[Extractor.from_dict(e) for e in (data.get("extract") or [])],
+            assertions=[Assertion.from_dict(a) for a in (data.get("assertions") or [])],
+            send_cookies=send_cookies,
+            max_range_bytes=int(max_range) if max_range is not None else None,
+        )
+
+
+@dataclass
+class Chain:
+    """A named, ordered sequence of steps that together prove one vulnerability."""
+
+    name: str
+    steps: List[ChainStep] = field(default_factory=list)
+    vuln_type: str = "attack_chain"
+    description: str = ""
+
+    @staticmethod
+    def from_dict(data: Dict[str, Any]) -> "Chain":
+        return Chain(
+            name=str(data.get("name", "")).strip() or "attack_chain",
+            steps=[ChainStep.from_dict(s) for s in (data.get("steps") or [])],
+            vuln_type=str(data.get("vuln_type", "attack_chain")).strip() or "attack_chain",
+            description=str(data.get("description", "")),
+        )
+
+
+@dataclass
+class StepResult:
+    """Outcome of executing a single step (secrets redacted for reporting)."""
+
+    name: str
+    method: str
+    url: str
+    status: Optional[int] = None
+    passed: bool = False
+    assertion_results: List[str] = field(default_factory=list)
+    extracted: List[str] = field(default_factory=list)   # "var=redacted_preview"
+    note: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "method": self.method,
+            "url": self.url,
+            "status": self.status,
+            "passed": self.passed,
+            "assertions": self.assertion_results,
+            "extracted": self.extracted,
+            "note": self.note,
+        }
+
+
+@dataclass
+class ChainResult:
+    """Overall verdict for a chain.
+
+    status: confirmed | refuted | needs_auth | blocked | error
+      confirmed — every step's assertions passed end to end.
+      refuted   — a step ran but its assertions failed (the vuln did not reproduce).
+      blocked   — a step was refused by the scope or payload-safety gate.
+      needs_auth— a step hit an auth wall; supply a session and re-run.
+      error     — a step could not be sent (network/parse).
+    """
+
+    name: str
+    status: str
+    vuln_type: str = "attack_chain"
+    steps: List[StepResult] = field(default_factory=list)
+    evidence: str = ""
+
+    @property
+    def confirmed(self) -> bool:
+        return self.status == "confirmed"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "vuln_type": self.vuln_type,
+            "confirmed": self.confirmed,
+            "steps": [s.to_dict() for s in self.steps],
+            "evidence": self.evidence,
+        }

--- a/dast/chains/planner.py
+++ b/dast/chains/planner.py
@@ -1,0 +1,79 @@
+"""
+Attack-chain planner.
+
+Turns a free-text multi-step vulnerability report into an executable
+:class:`Chain`. This is what lets a "chain of attack" described in prose (a
+HackerOne submission, an internal write-up) become something ChainEngine can
+run and confirm. The report text is untrusted evidence, so it is fenced with
+``wrap_untrusted`` and the system prompt carries the injection-defense directive.
+
+The LLM output is schema-forced (``ATTACK_CHAIN_SCHEMA``) so malformed specs
+cannot occur; on any AI failure the planner degrades to ``None`` and the caller
+falls back to manual review.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from dast.ai import bedrock_client
+from dast.ai.prompt_safety import UNTRUSTED_CONTENT_DIRECTIVE, wrap_untrusted
+from dast.ai.schemas import ATTACK_CHAIN_SCHEMA
+from dast.chains.models import Chain
+from dast.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_SYSTEM = (
+    "You are a security engineer turning a written multi-step vulnerability report into an "
+    "executable request chain that PROVES the issue. A chain is an ordered list of HTTP "
+    "requests where each step can bind values out of its response (a token, a Set-Cookie, an "
+    "unguessable path leaked by a field) that later steps consume via {{variable}} templates.\n\n"
+    "Rules:\n"
+    "1. Reproduce faithfully: use the exact hosts, paths, methods, headers and bodies from the "
+    "report. Do not invent endpoints.\n"
+    "2. Thread state: if step 1 returns a token or cookie that step 2 needs, add an extractor in "
+    "step 1 and reference the variable in step 2. Set-Cookie is harvested automatically.\n"
+    "3. Assertions encode the expected evidence (status codes, header/body substrings, that a "
+    "leaked value is present).\n"
+    "4. ALWAYS end with a CONTROL step: repeat the sensitive request but WITHOUT the credential "
+    "that supposedly grants access (send_cookies: []), asserting it now FAILS (e.g. status_in "
+    "[401,403]). This is what separates a real access-control break from normal behavior.\n"
+    "5. SAFETY: this runs against a LIVE target. Never write/delete/mutate data. When a step "
+    "fetches content/media, set max_range_bytes to a small value (e.g. 64) so only a proof-sized "
+    "slice is requested, never the full asset. Detection only.\n"
+    "6. Keep the chain minimal — the fewest steps that prove the claim."
+)
+_SYSTEM += UNTRUSTED_CONTENT_DIRECTIVE
+
+
+def plan_chain(report_text: str, model_id: Optional[str] = None) -> Optional[Chain]:
+    """Plan an executable chain from a free-text report. Returns None on failure."""
+    report_text = (report_text or "").strip()
+    if not report_text:
+        return None
+    user = (
+        "Turn the following multi-step vulnerability report into an executable chain spec. "
+        "Include a control step as instructed.\n\n"
+        + wrap_untrusted(report_text, "vuln_report", 8000)
+    )
+    try:
+        data = bedrock_client.invoke_json(
+            system=_SYSTEM,
+            user=user,
+            model_id=model_id,
+            max_tokens=3000,
+            temperature=0,
+            cache_system=True,
+            schema=ATTACK_CHAIN_SCHEMA,
+        )
+    except Exception as exc:
+        logger.warning("chain planning failed", error=str(exc))
+        return None
+
+    chain = Chain.from_dict(data)
+    if not chain.steps:
+        logger.warning("chain planner returned no steps")
+        return None
+    logger.info("chain planned", name=chain.name, steps=len(chain.steps), vuln_type=chain.vuln_type)
+    return chain

--- a/dast/tools/__init__.py
+++ b/dast/tools/__init__.py
@@ -15,6 +15,7 @@ from dast.tools.base import Tool, all_tools, get_tool, register, run_tool
 from dast.tools.context import ToolContext
 
 # Import side effects register the built-in tools.
+from dast.tools import chain_tools as _chain_tools  # noqa: F401
 from dast.tools import encoding_tools as _encoding_tools  # noqa: F401
 from dast.tools import findings_tools as _findings_tools  # noqa: F401
 from dast.tools import history_tools as _history_tools  # noqa: F401

--- a/dast/tools/chain_tools.py
+++ b/dast/tools/chain_tools.py
@@ -1,0 +1,164 @@
+"""
+validate_chain tool — reproduce and validate a multi-step attack chain.
+
+A single request cannot prove an exploit whose later steps depend on data leaked
+by earlier ones (a guest token + signed cookies, an unguessable path disclosed
+by a GraphQL field, then content fetched with those cookies). This tool runs
+such a chain end to end through the proxy: every step is scope-gated and
+payload-safety gated, Set-Cookie is threaded forward, variables bind response
+data into later requests, and a final control step proves the credential is what
+defeats the check.
+
+Accepts either a ready ``chain`` spec (see dast/chains/models.py) or free-text
+``report_text`` that the LLM planner turns into one. Wraps ``dast.chains`` — the
+handler stays thin per the tool-layer conventions.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+from dast.chains.engine import ChainEngine
+from dast.chains.models import Chain
+from dast.tools.base import Tool, register
+from dast.tools.context import ToolContext
+from dast.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_VALIDATE_CHAIN_SCHEMA: Dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "chain": {
+            "type": "object",
+            "description": (
+                "A ready chain spec: {name, vuln_type, description, steps:[...]}. Each step is "
+                "{name, method, url, headers, body, send_cookies, max_range_bytes, extract:[...], "
+                "assertions:[...]}. Provide this OR report_text."
+            ),
+        },
+        "report_text": {
+            "type": "string",
+            "description": (
+                "Free-text multi-step report (e.g. a HackerOne submission). The planner turns it "
+                "into an executable chain, including a control step. Provide this OR chain."
+            ),
+        },
+    },
+}
+
+
+def _host(url: str) -> str:
+    try:
+        return urlparse(url).netloc.lower()
+    except Exception:
+        return ""
+
+
+async def _make_sender(ctx: ToolContext):
+    import httpx
+
+    async def _sender(method: str, url: str, headers: Dict[str, str], body: str):
+        request_body = body if method in ("POST", "PUT", "PATCH", "DELETE") else ""
+        # A fresh client per request: no implicit httpx cookie jar carries state
+        # between steps — the engine's explicit jar is the only cookie source, so
+        # a control step that sends none really sends none.
+        async with httpx.AsyncClient(
+            proxy=ctx.proxy_url, verify=False, follow_redirects=False, timeout=15,
+        ) as client:
+            resp = await client.request(
+                method, url, headers=headers or None,
+                content=request_body.encode("utf-8") if request_body else None,
+            )
+        resp_headers: Dict[str, str] = {}
+        for key, value in resp.headers.multi_items():
+            if key.lower() == "set-cookie":
+                existing = resp_headers.get("set-cookie", "")
+                resp_headers["set-cookie"] = f"{existing}, {value}" if existing else value
+            else:
+                resp_headers[key] = value
+        return resp.status_code, resp_headers, resp.text
+
+    return _sender
+
+
+async def _validate_chain(ctx: ToolContext, args: Dict[str, Any]) -> Dict[str, Any]:
+    chain_spec: Optional[Dict[str, Any]] = args.get("chain")
+    report_text = str(args.get("report_text", "")).strip()
+
+    if not chain_spec and not report_text:
+        return {"ok": False, "error": "provide either 'chain' or 'report_text'"}
+
+    # Build the chain: explicit spec wins; otherwise plan from the report.
+    if chain_spec:
+        try:
+            chain = Chain.from_dict(chain_spec)
+        except Exception as exc:
+            return {"ok": False, "error": f"invalid chain spec: {str(exc)[:200]}"}
+    else:
+        import asyncio
+
+        from dast.chains.planner import plan_chain
+        loop = asyncio.get_running_loop()
+        chain = await loop.run_in_executor(None, lambda: plan_chain(report_text))
+        if chain is None:
+            return {"ok": False, "error": "could not plan a chain from the report (AI unavailable or no steps)"}
+
+    if not chain.steps:
+        return {"ok": False, "error": "chain has no steps"}
+
+    # Scope gate up front over every literal host in the chain. An MCP caller
+    # (no in-process store) can request an interactive per-target approval, like
+    # send_request, so an out-of-scope reported target can still be validated.
+    approved_hosts: set = set()
+    for step in chain.steps:
+        host = _host(step.url)
+        if not host:
+            continue  # templated host — the engine gates the rendered URL at runtime
+        if ctx.is_in_scope(step.url) or host in approved_hosts:
+            continue
+        if ctx.store is None:
+            from dast.tools import approval
+            if await approval.request_approval(ctx, step.url, step.method):
+                approved_hosts.add(host)
+                continue
+        return {"ok": False, "error": "chain target is out of scope", "url": step.url, "host": host}
+
+    def _in_scope(url: str) -> bool:
+        return ctx.is_in_scope(url) or _host(url) in approved_hosts
+
+    sender = await _make_sender(ctx)
+    engine = ChainEngine(sender=sender, is_in_scope=_in_scope)
+    result = await engine.run(chain)
+
+    return {
+        "ok": True,
+        "status": result.status,
+        "confirmed": result.confirmed,
+        "vuln_type": result.vuln_type,
+        "name": result.name,
+        "steps": [s.to_dict() for s in result.steps],
+        "evidence": result.evidence[:4000],
+    }
+
+
+register(Tool(
+    name="validate_chain",
+    description=(
+        "Validate a MULTI-STEP attack chain against the target: run an ordered sequence of "
+        "requests where later steps consume data (tokens, cookies, leaked paths) bound from "
+        "earlier responses, then a control step proves the credential is what defeats the "
+        "check. Routes every step through the proxy, scope-gated and payload-safety gated, and "
+        "returns a per-step verdict (confirmed/refuted/needs_auth/blocked).\n"
+        "Use this when: a report describes a chain of requests (unauth bootstrap -> token -> "
+        "privileged read -> content fetch), or single-request triage_report cannot express the "
+        "dependency between steps. Pass 'report_text' to have the chain planned for you, or a "
+        "ready 'chain' spec to run it verbatim.\n"
+        "Do NOT use this for: a single request (use send_request); a report that reproduces in "
+        "one request (use triage_report); or listing existing findings (use get_findings)."
+    ),
+    input_schema=_VALIDATE_CHAIN_SCHEMA,
+    handler=_validate_chain,
+    tags=["triage", "http"],
+))

--- a/tests/unit/test_chain_engine.py
+++ b/tests/unit/test_chain_engine.py
@@ -1,0 +1,233 @@
+"""
+Unit tests for the multi-step attack-chain engine (dast/chains).
+
+Drives the engine with a scripted, offline sender modelled on a common
+signed-cookie access-control pattern (unauthenticated bootstrap -> guest token +
+signed cookies -> a GraphQL field that leaks an unguessable CDN path -> content
+fetch with the anon cookies -> control request that must fail). Covers extraction
+(json / set_cookie / b64json / jwt_claim), template substitution, cookie
+threading, control-step logic, and the scope + payload-safety gates.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from dast.chains.engine import ChainEngine
+from dast.chains.models import Chain
+
+
+def _b64url(obj) -> str:
+    raw = json.dumps(obj).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+# CloudFront policy naming a host-agnostic wildcard resource.
+_POLICY = _b64url({"Statement": [{"Resource": "*/downloads/*",
+                                  "Condition": {"DateLessThan": {"AWS:EpochTime": 1789057813}}}]})
+# Guest JWT whose claims show no entitlement (synthetic, fictional).
+_JWT = "eyJhbGciOiJSUzI1NiJ9." + _b64url({
+    "account": {"can_download": False, "can_preview": False,
+                "subscription_level": None, "purchased_skus": []},
+}) + ".sig"
+_BASE_PATH = "downloads/pkg/AbCd1234XyZ/"
+
+
+def _scripted_sender():
+    """A fake sender that emulates a target's per-step responses."""
+    calls = []
+
+    async def sender(method, url, headers, body):
+        calls.append((method, url, dict(headers), body))
+        has_cookie = "Cookie" in headers and "CloudFront-Policy" in headers.get("Cookie", "")
+        has_bearer = "Bearer " in headers.get("Authorization", "")
+
+        if url.endswith("/api/session"):
+            set_cookie = (
+                f"CloudFront-Policy={_POLICY}; path=/downloads, "
+                f"CloudFront-Signature=abc123~def; path=/downloads, "
+                f"CloudFront-Key-Pair-Id=APKAEXAMPLE00000000; path=/"
+            )
+            body_json = json.dumps({"guest": {"cdnJwt": _JWT}, "permissions": {}})
+            return 200, {"content-type": "application/json", "set-cookie": set_cookie}, body_json
+
+        if url.endswith("/api/graphql") and has_bearer:
+            translations = [
+                {"language": {"code": "en-gb"},
+                 "activePackage": {"id": 580079, "fileList": {"basePath": _BASE_PATH}}},
+                {"language": {"code": "de-de"},
+                 "activePackage": {"id": 580080, "fileList": {"basePath": "downloads/pkg/OTHER/"}}},
+            ]
+            return 200, {"content-type": "application/json"}, json.dumps(
+                {"data": {"storeItem": {"translations": translations}}})
+
+        if _BASE_PATH in url:
+            if has_cookie:
+                return 206, {"content-type": "video/MP2T", "content-range": "bytes 0-63/6677760"}, "x" * 64
+            return 403, {"content-type": "text/xml", "server": "CloudFront"}, "<Error><Code>MissingKey</Code></Error>"
+
+        return 404, {}, "not found"
+
+    return sender, calls
+
+
+def _signed_cookie_chain() -> dict:
+    return {
+        "name": "guest-token-cdn-access",
+        "vuln_type": "broken_access_control",
+        "description": "Unauthenticated guest token + wildcard CloudFront cookies defeat a CDN paywall.",
+        "steps": [
+            {
+                "name": "bootstrap",
+                "method": "GET",
+                "url": "https://store.example.com/api/session",
+                "extract": [
+                    {"kind": "json", "var": "jwt", "expr": "guest.cdnJwt"},
+                    {"kind": "set_cookie", "var": "policy", "expr": "CloudFront-Policy"},
+                    {"kind": "b64json", "var": "resource", "expr": "Statement[0].Resource", "from": "var:policy"},
+                    {"kind": "jwt_claim", "var": "can_dl", "expr": "account.can_download", "from": "var:jwt"},
+                ],
+                "assertions": [
+                    {"kind": "status_eq", "value": 200},
+                    {"kind": "var_present", "var": "jwt"},
+                    {"kind": "var_contains", "var": "resource", "needle": "*/downloads/*"},
+                    {"kind": "var_equals", "var": "can_dl", "value": "false"},
+                ],
+            },
+            {
+                "name": "leak-basepath",
+                "method": "POST",
+                "url": "https://store.example.com/api/graphql",
+                "headers": {"Authorization": "Bearer {{jwt}}", "Content-Type": "application/json"},
+                "body": "{\"query\":\"{storeItem(uuid:\\\"x\\\"){translations{activePackage{fileList{basePath}}}}}\"}",
+                "extract": [
+                    {"kind": "json", "var": "base_path",
+                     "expr": "data.storeItem.translations[*].activePackage.fileList.basePath"},
+                ],
+                "assertions": [
+                    {"kind": "status_eq", "value": 200},
+                    {"kind": "var_present", "var": "base_path"},
+                ],
+            },
+            {
+                "name": "fetch-content",
+                "method": "GET",
+                "url": "https://store.example.com/{{base_path}}config.json",
+                "max_range_bytes": 64,
+                "assertions": [
+                    {"kind": "status_eq", "value": 206},
+                    {"kind": "header_contains", "name": "content-range", "needle": "/6677760"},
+                ],
+            },
+            {
+                "name": "control-no-cookies",
+                "method": "GET",
+                "url": "https://store.example.com/{{base_path}}config.json",
+                "send_cookies": [],
+                "assertions": [
+                    {"kind": "status_in", "values": [401, 403]},
+                    {"kind": "body_contains", "needle": "MissingKey"},
+                ],
+            },
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_signed_cookie_chain_confirms_end_to_end():
+    sender, calls = _scripted_sender()
+    engine = ChainEngine(sender=sender, is_in_scope=lambda u: True)
+    result = await engine.run(Chain.from_dict(_signed_cookie_chain()))
+
+    assert result.status == "confirmed"
+    assert result.confirmed is True
+    assert [s.passed for s in result.steps] == [True, True, True, True]
+
+    # The Bearer token bound in step 1 was threaded into step 2's header.
+    graphql_call = next(c for c in calls if c[1].endswith("/graphql"))
+    assert "Bearer eyJ" in graphql_call[2]["Authorization"]
+
+    # The leaked basePath was templated into step 3's URL.
+    content_call = calls[2]
+    assert _BASE_PATH in content_call[1]
+    # Content fetch was range-capped (never pulls the full asset).
+    assert content_call[2].get("Range") == "bytes=0-63"
+
+    # The control step sent NO cookies.
+    control_call = calls[3]
+    assert "Cookie" not in control_call[2]
+
+    # Secrets are redacted in the reported evidence.
+    assert _JWT not in result.evidence
+
+
+@pytest.mark.asyncio
+async def test_control_step_passing_means_credential_not_required():
+    """If the 'control' request also succeeds, the cookies were not what mattered."""
+    async def sender(method, url, headers, body):
+        return 206, {"content-range": "bytes 0-63/100"}, "x" * 64
+
+    chain = {
+        "name": "c", "vuln_type": "x",
+        "steps": [{
+            "name": "control", "url": "https://t.example.com/asset",
+            "send_cookies": [],
+            "assertions": [{"kind": "status_in", "values": [401, 403]}],
+        }],
+    }
+    engine = ChainEngine(sender=sender, is_in_scope=lambda u: True)
+    result = await engine.run(Chain.from_dict(chain))
+    assert result.status == "refuted"
+    assert result.steps[0].passed is False
+
+
+@pytest.mark.asyncio
+async def test_out_of_scope_step_is_blocked_and_not_sent():
+    sent = []
+
+    async def sender(method, url, headers, body):
+        sent.append(url)
+        return 200, {}, ""
+
+    chain = {"name": "c", "vuln_type": "x", "steps": [
+        {"name": "s", "url": "https://evil.example.com/x"},
+    ]}
+    engine = ChainEngine(sender=sender, is_in_scope=lambda u: False)
+    result = await engine.run(Chain.from_dict(chain))
+    assert result.status == "blocked"
+    assert sent == []  # nothing left the process
+
+
+@pytest.mark.asyncio
+async def test_destructive_payload_is_refused():
+    sent = []
+
+    async def sender(method, url, headers, body):
+        sent.append(url)
+        return 200, {}, ""
+
+    chain = {"name": "c", "vuln_type": "x", "steps": [
+        {"name": "s", "method": "POST", "url": "https://t.example.com/admin",
+         "body": "'; DROP TABLE users; --"},
+    ]}
+    engine = ChainEngine(sender=sender, is_in_scope=lambda u: True)
+    result = await engine.run(Chain.from_dict(chain))
+    assert result.status == "blocked"
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_auth_wall_routes_to_needs_auth():
+    async def sender(method, url, headers, body):
+        return 401, {}, "login required"
+
+    chain = {"name": "c", "vuln_type": "x", "steps": [
+        {"name": "s", "url": "https://t.example.com/private",
+         "assertions": [{"kind": "status_eq", "value": 200}]},
+    ]}
+    engine = ChainEngine(sender=sender, is_in_scope=lambda u: True)
+    result = await engine.run(Chain.from_dict(chain))
+    assert result.status == "needs_auth"

--- a/tests/unit/test_tools_registry.py
+++ b/tests/unit/test_tools_registry.py
@@ -33,7 +33,7 @@ class _Scope:
 def test_registry_lists_builtin_tools():
     names = {t.name for t in tools.all_tools()}
     assert {"send_request", "get_history", "content_discovery",
-            "param_mining", "triage_report", "list_login_profiles",
+            "param_mining", "triage_report", "validate_chain", "list_login_profiles",
             "get_findings", "oob_generate", "oob_poll",
             "url_encode", "url_decode", "base64_encode", "base64_decode",
             "html_encode", "html_decode"} <= names
@@ -358,6 +358,27 @@ async def test_send_request_out_of_scope_allowed_by_approval(monkeypatch):
     result = await run_tool(ctx, "send_request", {"url": "https://newtarget.example.com/x"})
     assert result["ok"] is True
     assert result["status"] == 200
+
+
+# ── validate_chain scope + args ─────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_validate_chain_requires_input():
+    ctx = ToolContext(settings=_Scope(True))
+    result = await run_tool(ctx, "validate_chain", {})
+    assert result["ok"] is False
+    assert "chain" in result["error"] and "report_text" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_validate_chain_out_of_scope_blocked():
+    # store set (in-process) so no interactive approval is attempted.
+    ctx = ToolContext(store=object(), settings=_Scope(False))
+    spec = {"name": "c", "vuln_type": "x",
+            "steps": [{"name": "s", "url": "https://evil.example.com/x"}]}
+    result = await run_tool(ctx, "validate_chain", {"chain": spec})
+    assert result["ok"] is False
+    assert "out of scope" in result["error"]
 
 
 # ── MCP conversion (pure, no mcp import) ────────────────────────────────────────


### PR DESCRIPTION
## What

Adds a data-driven subsystem to validate **multi-step attack chains** — ordered requests where later steps consume state (tokens, cookies, leaked paths) bound from earlier responses, closed by a control step that must fail to attribute the result to the credential under test.

The single-request `triage_report` strategies cannot express the dependency between steps, so chained access-control reports (unauth bootstrap -> token -> privileged read -> content fetch) could not be validated end to end.

## How

- `dast/chains/models.py` — `Chain` / `ChainStep` / `Extractor` / `Assertion` / `StepResult` / `ChainResult`; `{{var}}` state templating; statuses `confirmed / refuted / needs_auth / blocked / error`.
- `dast/chains/engine.py` — `ChainEngine` runs ordered steps, threads variables and cookies forward, scope-gates and payload-safety-gates every step before it fires, caps ranged fetches with a `Range` header, and redacts tokens/cookies from reported evidence.
- `dast/chains/planner.py` — LLM planner turns a free-text report into a chain spec (schema-forced, detection-only, control step required); degrades to `None` on failure.
- `dast/ai/schemas.py` — `ATTACK_CHAIN_SCHEMA`.
- `dast/tools/chain_tools.py` — `validate_chain` tool (accepts a ready `chain` spec or `report_text`); a fresh httpx client per step so no cookie jar leaks between steps. Registered in the shared tool layer, so it is advertised over MCP automatically.

## Safety

Out-of-scope and destructive steps are blocked before any request leaves the process. Every step routes through the proxy (scope + payload-safety gated), so all traffic is captured in history for auditing.

## Tests

`tests/unit/test_chain_engine.py` uses a fully synthetic signed-cookie scenario: the chain confirms end to end offline, a control-passing variant refutes, out-of-scope and destructive steps are blocked and never sent, and an auth wall routes to `needs_auth`. Registry test updated for the new tool.

`uv run pytest tests/unit/test_chain_engine.py tests/unit/test_tools_registry.py` and `make lint` both green.